### PR TITLE
fix: relate() errors on missing endpoint instead of false success

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,13 @@ c0 init --namespace my-project
 
 # 6. Add knowledge and recall it
 c0 add concept "reciprocal rank fusion" -d "Rank-based fusion of multiple result lists; score = weight/(k+rank)."
-c0 relate "reciprocal rank fusion" USED_BY "hybrid search"
-c0 walk "hybrid search"
+c0 add concept "hybrid search" -d "Keyword (BM25) + vector retrieval, fused by RRF." --force
+c0 relate "reciprocal rank fusion" USED_BY "hybrid search"   # both endpoints must exist
+c0 walk "reciprocal rank fusion"                             # traverses outgoing edges -> "hybrid search"
 ```
+
+> `--force` on the second concept skips the *similar-concept* guard: closely related ideas
+> often score as near-duplicates, and `relate` requires both endpoints to already exist.
 
 ## Core commands
 
@@ -101,6 +105,25 @@ c0 reads connection details from the environment, with a per-namespace `.c0/conf
 | `ANTHROPIC_API_KEY` | — | Optional; reflector classification & extraction |
 
 Embedding host/model (Ollama) default to `http://localhost:11434` and `nomic-embed-text`, and are configurable.
+
+## Using c0 with Claude Code
+
+c0 pays off most when you treat the **graph as where knowledge lives** and keep your `CLAUDE.md` for **protocol** — the instruction to consult c0, plus your own house rules. Project facts, API shapes, and architecture decisions go stale fast and bloat every prompt when hard-coded into `CLAUDE.md`; put them in the graph instead and let the model pull the relevant subgraph on demand, then *correct* it over time with patches and supersessions.
+
+The one thing `CLAUDE.md` **does** need is an instruction to actually reach for c0. A minimal version:
+
+```md
+## Memory
+
+Before answering questions about this project's stack, architecture, or APIs,
+run `c0 walk "<topic>"` first and use what it returns — it patches stale
+training knowledge. As you learn durable facts, write them back with
+`c0 add concept` / `c0 relate` so the next session inherits them.
+```
+
+Keep your preferences and conventions in `CLAUDE.md` as usual — just stop hand-maintaining *knowledge* there. For hands-off recall, wire `c0 walk` into a [Claude Code hook](https://docs.claude.com/en/docs/claude-code/hooks) so the lookup happens automatically on matching prompts.
+
+> This is a workflow suggestion, not a setup requirement — c0 is a plain CLI and works with any assistant (or none). Adopt as much of the pattern as suits you.
 
 ## Optional: Claude Code session indexing
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
 use neo4rs::{Graph, query};
 use std::collections::HashMap;
@@ -418,23 +418,40 @@ pub async fn relate(
         format!(
             "MATCH (a:Concept {{name: $from}}), (b:KnowledgePatch {{name: $to}}) \
              WHERE a.namespace IN $namespaces AND (b.namespace IS NULL OR b.namespace IN $namespaces) \
-             CREATE (a)-[:{rel_type}]->(b)"
+             CREATE (a)-[:{rel_type}]->(b) RETURN count(*) AS created"
         )
     } else {
         format!(
             "MATCH (a:Concept {{name: $from}}), (b:Concept {{name: $to}}) \
              WHERE a.namespace IN $namespaces AND b.namespace IN $namespaces \
-             CREATE (a)-[:{rel_type}]->(b)"
+             CREATE (a)-[:{rel_type}]->(b) RETURN count(*) AS created"
         )
     };
-    graph
-        .run(
+    let mut result = graph
+        .execute(
             query(&cypher)
                 .param("from", from)
                 .param("to", to)
                 .param("namespaces", namespaces.to_vec()),
         )
         .await?;
+
+    let created = match result.next().await? {
+        Some(row) => row.get::<i64>("created").unwrap_or(0),
+        None => 0,
+    };
+    if created == 0 {
+        let target_kind = if rel_type == "HAS_PATCH" {
+            "patch"
+        } else {
+            "concept"
+        };
+        return Err(anyhow!(
+            "Could not create relationship '{from}' -[{rel_type}]-> '{to}': \
+             the source concept and/or target {target_kind} was not found in \
+             namespaces {namespaces:?}. Create both first (e.g. `c0 add concept`)."
+        ));
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## What

`c0 relate <a> <TYPE> <b>` reported success even when an endpoint concept didn't exist, but persisted no edge.

**Root cause:** `relate()` ran a `MATCH (a),(b) ... CREATE (a)-[..]->(b)` via `graph.run()`. When either node doesn't match, `MATCH` returns zero rows, `CREATE` never fires, and `run()` still returns `Ok` — so the CLI printed the success arrow with nothing written.

The documented Quickstart depended on this bug: it related `"reciprocal rank fusion"` to a `"hybrid search"` concept it never created.

## Changes

- **`src/graph.rs`** — `relate()` now `RETURN count(*)` via `execute()` and returns a clear error when the `MATCH` produces no rows (source and/or target not found in the active namespaces).
- **`README.md`** — fixed the Quickstart to create both endpoints and walk from the edge's source (so the traversal actually shows the connection).
- **`README.md`** — added a **"Using c0 with Claude Code"** section: keep *knowledge* in the graph and *protocol* in `CLAUDE.md`, with an optional copy-paste snippet. Framed as a suggestion, not a requirement.

## Verification

- Missing endpoint → exit 1, clear message, no phantom edge.
- Both endpoints present → edge created, exit 0, `walk` traverses it.
- Corrected Quickstart runs verbatim (exit 0).
- Clean build (default + `--features sessions`); `cargo test` 10/10 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)