### PR TITLE
fix(cli): exit non-zero on add concept/patch validation errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1273,7 +1273,8 @@ async fn main() -> Result<()> {
                 {
                     anyhow::bail!(
                         "'{}' is not in the namespace chain {:?}",
-                        target, ctx.namespaces
+                        target,
+                        ctx.namespaces
                     );
                 }
 
@@ -1386,7 +1387,8 @@ async fn main() -> Result<()> {
                 {
                     anyhow::bail!(
                         "'{}' is not in the namespace chain {:?}",
-                        target, ctx.namespaces
+                        target,
+                        ctx.namespaces
                     );
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1271,11 +1271,10 @@ async fn main() -> Result<()> {
                 if let Some(ref target) = to
                     && !ctx.namespaces.contains(target)
                 {
-                    eprintln!(
-                        "Error: '{}' is not in the namespace chain {:?}",
+                    anyhow::bail!(
+                        "'{}' is not in the namespace chain {:?}",
                         target, ctx.namespaces
                     );
-                    return Ok(());
                 }
 
                 let embed_text = match &description {
@@ -1369,17 +1368,14 @@ async fn main() -> Result<()> {
                 valid_at,
             } => {
                 if file.is_none() && content.is_none() {
-                    eprintln!(
-                        "Error: a patch needs content. Pass --file <path> or --content <text>."
+                    anyhow::bail!(
+                        "a patch needs content. Pass --file <path> or --content <text>.\n       (a patch with neither renders empty on walk)"
                     );
-                    eprintln!("       (a patch with neither renders empty on walk)");
-                    return Ok(());
                 }
                 if let Some(f) = &file {
                     let expanded = shellexpand::tilde(f).to_string();
                     if !std::path::Path::new(&expanded).exists() {
-                        eprintln!("Error: --file not found: {f}");
-                        return Ok(());
+                        anyhow::bail!("--file not found: {f}");
                     }
                 }
 
@@ -1388,11 +1384,10 @@ async fn main() -> Result<()> {
                 if let Some(ref target) = to
                     && !ctx.namespaces.contains(target)
                 {
-                    eprintln!(
-                        "Error: '{}' is not in the namespace chain {:?}",
+                    anyhow::bail!(
+                        "'{}' is not in the namespace chain {:?}",
                         target, ctx.namespaces
                     );
-                    return Ok(());
                 }
 
                 let valid_at_dt = valid_at


### PR DESCRIPTION
## What

`add patch` validation (empty patch, `--file` not found, `--to` namespace not in chain) and the `add concept --to` namespace check printed `Error: ...` to stderr but then `return Ok(())` — so the process exited **0**. A script checking `$?` would treat a rejected command as success, inconsistent with `relate()` (which exits 1).

## Fix

Convert these four paths to `anyhow::bail!` so they propagate through `main()` and exit 1 (anyhow supplies the `Error:` prefix). User-facing messages are unchanged.

## Verification

| Case | Exit before | Exit after |
|---|---|---|
| `add patch` empty (no `--file`/`--content`) | 0 | **1** |
| `add patch --file <missing>` | 0 | **1** |
| `add patch --to <bad-ns>` | 0 | **1** |
| `add concept --to <bad-ns>` | 0 | **1** |
| valid `add patch --content` | 0 | 0 ✓ |

Clean build (default + `--features sessions`); `cargo test` 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)