### PR TITLE
feat(reflector): add `c0 reflector run` watch mode for the learning loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ query ──▶ ❶ exact match ─▶ ❷ keyword (BM25) ─▶ ❸ hybrid (BM2
 - **Graph storage (Neo4j).** Knowledge lives as `Concept` nodes and typed relationships, not as text chunks — so retrieval can *traverse* from one idea to related ones.
 - **Hybrid retrieval.** A tiered cascade: exact match → keyword (Lucene/BM25) → **hybrid**, which runs keyword *and* vector search and merges them with **Reciprocal Rank Fusion (RRF)**. Keyword nails exact names and identifiers; vectors catch synonyms and paraphrase; fusion gets the best of both without normalizing incompatible score scales.
 - **Bi-temporal.** Every concept carries two independent timestamps — when it was *recorded* (transaction time) and when it is *true* (valid time) — so you can run point-in-time ("as-of") queries, **supersede** a concept when it evolves, or **invalidate** it with a causal audit trail. Nothing is deleted; it's time-bounded.
-- **Self-improving reflection loop.** When a lookup finds nothing, the dead end is queued, and an LLM classifies it: **commit** a genuinely new, reusable concept, **discard** noise, or **queue** the uncertain ones for human review.
+- **Self-improving reflection loop.** When a lookup finds nothing, the dead end is queued, and an LLM classifies it: **commit** a genuinely new, reusable concept, **discard** noise, or **queue** the uncertain ones for human review. Run it continuously (`c0 reflector run`) and c0 fills its own memory gaps as you work — [details below](#the-reflection-loop--c0s-learning-engine).
 
 ## Requirements
 
@@ -88,7 +88,7 @@ c0 walk "reciprocal rank fusion"                             # traverses outgoin
 | `c0 supersede <old> --with <new>` | Mark a concept evolved into a newer one |
 | `c0 invalidate concept <name> --reason "<why>"` | Retract a concept with a causal trail |
 | `c0 describe <concept> "<new desc>"` | Update a description (and re-embed) |
-| `c0 reflector ...` | Inspect/process the dead-end → learn loop |
+| `c0 reflector run` | Run the learning loop: classify dead ends → commit new concepts (see [below](#the-reflection-loop--c0s-learning-engine)) |
 | `c0 health --fix` | Check Neo4j / Ollama / indexes |
 | `c0 export` · `c0 audit` · `c0 move` | Maintenance utilities |
 
@@ -134,6 +134,51 @@ cargo install --path . --features sessions
 ```
 
 This is the reference example of c0's **source-adapter** pattern — the same shape any "fill the graph from <source>" integration would take.
+
+## The reflection loop — c0's learning engine
+
+This is the part that makes c0 *memory* rather than a database: it learns from what it **fails** to find. Every time `c0 walk` comes up empty, that query is recorded as a dead end (`~/.c0/reflector/inbox.jsonl`). The reflection loop turns those misses into knowledge — an LLM classifies each one:
+
+- **COMMIT** — a genuinely new, reusable concept worth adding to the graph
+- **DISCARD** — noise (typos, test queries, local paths)
+- **QUEUE** — uncertain; leave it for a human to judge
+
+Run unattended, this is a flywheel: the more you use c0, the more the gaps in its memory get noticed, classified, and filled — so the *next* lookup that would have missed now hits.
+
+### Run it (the whole point)
+
+The loop only pays off if it runs regularly. The simplest way is the built-in watch mode — it classifies the inbox, applies the commits, sleeps, and repeats:
+
+```bash
+c0 reflector run                      # tick every hour, auto-commit the COMMITs
+c0 reflector run --interval 15m       # tick more often
+c0 reflector run --no-apply           # classify only; hold COMMITs for human review
+```
+
+For an always-on, unattended setup, prefer the OS scheduler over a long-lived process — cron and systemd handle restarts and logging for you:
+
+```cron
+# Classify dead ends every hour and auto-commit. Keep a human in the loop?
+# Drop the "&& c0 reflector apply" and run `c0 reflector review` when you check in.
+0 * * * * c0 reflector process && c0 reflector apply
+```
+
+### Inspect and steer it
+
+The loop is intentionally two-staged (`process` → `apply`) so nothing touches the graph until you say so:
+
+```bash
+c0 reflector status     # how many dead ends are waiting, proposed, or queued
+c0 reflector process    # LLM classifies the inbox (writes pending commits + review queue)
+c0 reflector proposed   # preview the concepts it wants to COMMIT
+c0 reflector apply      # add the pending concepts to the graph
+c0 reflector review     # walk the QUEUE'd items interactively
+c0 reflector inbox      # show the raw dead-end inbox
+c0 reflector notify     # emit a summary of the queue state
+c0 reflector clear      # empty the inbox / pending queues
+```
+
+> Classification uses `ANTHROPIC_API_KEY`. Without it, dead ends still accumulate in the inbox — you just can't auto-classify them until a key is set.
 
 ## Architecture notes
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,6 +347,15 @@ enum ReflectorCommands {
     Clear,
     Process,
     Notify,
+    /// Run the loop continuously: classify the inbox, apply commits, then sleep.
+    Run {
+        /// How often to tick, e.g. 30s, 5m, 1h (a bare number means seconds).
+        #[arg(long, default_value = "1h")]
+        interval: String,
+        /// Classify only; leave COMMIT decisions in the queue for human review.
+        #[arg(long)]
+        no_apply: bool,
+    },
 }
 
 #[cfg(feature = "sessions")]
@@ -960,6 +969,10 @@ async fn main() -> Result<()> {
                 ReflectorCommands::Clear => reflector::clear()?,
                 ReflectorCommands::Process => reflector::process().await?,
                 ReflectorCommands::Notify => reflector::notify().await?,
+                ReflectorCommands::Run {
+                    interval,
+                    no_apply,
+                } => reflector::run(&interval, !no_apply).await?,
             }
             return Ok(());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -969,10 +969,9 @@ async fn main() -> Result<()> {
                 ReflectorCommands::Clear => reflector::clear()?,
                 ReflectorCommands::Process => reflector::process().await?,
                 ReflectorCommands::Notify => reflector::notify().await?,
-                ReflectorCommands::Run {
-                    interval,
-                    no_apply,
-                } => reflector::run(&interval, !no_apply).await?,
+                ReflectorCommands::Run { interval, no_apply } => {
+                    reflector::run(&interval, !no_apply).await?
+                }
             }
             return Ok(());
         }

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -373,6 +373,58 @@ pub fn apply() -> Result<()> {
     Ok(())
 }
 
+/// Parse a watch interval like `30s`, `5m`, `1h`. A bare number means seconds.
+fn parse_interval(spec: &str) -> Result<Duration> {
+    let spec = spec.trim();
+    let (digits, mult) = match spec.chars().last() {
+        Some('s') => (&spec[..spec.len() - 1], 1),
+        Some('m') => (&spec[..spec.len() - 1], 60),
+        Some('h') => (&spec[..spec.len() - 1], 3600),
+        _ => (spec, 1),
+    };
+
+    let n: u64 = digits
+        .trim()
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid interval '{spec}' (use e.g. 30s, 5m, 1h)"))?;
+    if n == 0 {
+        anyhow::bail!("interval must be greater than zero");
+    }
+
+    Ok(Duration::from_secs(n.saturating_mul(mult)))
+}
+
+/// Watch mode: classify the inbox, optionally apply commits, sleep, repeat.
+///
+/// Runs until interrupted (Ctrl-C). For an unattended setup, prefer a cron
+/// entry or a systemd unit — the OS handles restarts and logging.
+pub async fn run(interval: &str, apply_commits: bool) -> Result<()> {
+    let period = parse_interval(interval)?;
+
+    println!("c0 reflector watch — ticking every {interval} (Ctrl-C to stop)");
+    println!(
+        "Auto-apply: {}",
+        if apply_commits {
+            "on"
+        } else {
+            "off (COMMIT decisions stay in the review queue)"
+        }
+    );
+    println!("═══════════════════════════════════════");
+
+    loop {
+        if let Err(e) = process().await {
+            eprintln!("process failed: {e}");
+        }
+        if apply_commits
+            && let Err(e) = apply()
+        {
+            eprintln!("apply failed: {e}");
+        }
+        tokio::time::sleep(period).await;
+    }
+}
+
 const CLASSIFY_PROMPT: &str = r#"You are a knowledge system curator. Classify this dead-end query (a search that found nothing in the knowledge graph).
 
 Query: {query}

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -416,9 +416,7 @@ pub async fn run(interval: &str, apply_commits: bool) -> Result<()> {
         if let Err(e) = process().await {
             eprintln!("process failed: {e}");
         }
-        if apply_commits
-            && let Err(e) = apply()
-        {
+        if apply_commits && let Err(e) = apply() {
             eprintln!("apply failed: {e}");
         }
         tokio::time::sleep(period).await;


### PR DESCRIPTION
## What

Makes c0's reflection loop **runnable on its own** — the autonomous learning flywheel was the missing piece in the OSS build (the classify/commit logic already shipped; only the scheduling didn't).

### New command: `c0 reflector run`
A built-in watch mode that ticks on an interval: classify the dead-end inbox → apply the COMMIT decisions → sleep → repeat.

- `c0 reflector run` — tick hourly, auto-commit (default)
- `--interval 15m` — accepts `30s` / `5m` / `1h` (bare number = seconds), with validation
- `--no-apply` — classify only, holding COMMITs in the review queue for a human

For unattended production the README still recommends cron/systemd over a long-lived process — those handle restarts and logging better than a hand-rolled daemon.

### README
Reframes the reflection loop as a headline feature ("c0's learning engine"), leads with `run`, and links it from the How-it-works bullet and the core-commands table.

## Notes
- No new dependencies. `tokio::time` is already available transitively.
- Clean against default and `--features sessions` builds; adds zero new clippy warnings (pedantic).
- Split out of `fix/add-patch-exit-codes`, where it was accidentally stacked — zero overlap with that branch's commits.

## Test plan
- [x] `cargo build` and `cargo build --features sessions`
- [x] `cargo clippy` — no new warnings from this change
- [x] `c0 reflector run --help` renders; `--interval 0m` is rejected with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)