### PR TITLE
ci: bump actions/checkout to v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: build · test · lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## What

Bumps `actions/checkout@v4` → `@v5` in `.github/workflows/ci.yml`.

## Why

CI runs surface a deprecation warning: `actions/checkout@v4` runs on Node 20, which GitHub is removing from its runners (forced to Node 24 by default as of 2026-06-16, removed 2026-09-16). `v5` runs on Node 24.

No workflow behavior change — same checkout step, newer runtime.

## Test plan
- [x] CI passes on this branch with the bumped action

🤖 Generated with [Claude Code](https://claude.com/claude-code)