### PR TITLE
ci: group Dependabot minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,17 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Adds `groups` to `.github/dependabot.yml` so routine updates collapse into single PRs:
- **cargo** minor/patch bumps → one weekly PR
- **github-actions** bumps → one weekly PR

Major cargo updates are intentionally left ungrouped so they still get an individual PR and explicit review (e.g. the recent `dirs` 5→6).

## Why

Right now Dependabot opens one PR per dependency — that's how six separate PRs piled up. Grouping keeps the noise down while preserving review on breaking changes.

## Test plan
- [x] Valid Dependabot v2 schema; takes effect on the next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)