### PR TITLE
feat(sessions): make enrichment Ollama timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ The heavier work is **optional and runs in the background**. The reflection loop
 
 The short version: the embedding hot path is light enough for any laptop, and the only reason to add a GPU is to make the *optional* local LLM work faster — never to make c0 usable in the first place.
 
+> **On a slow CPU-only host, watch the enrichment timeout.** Recall stays fast (embeddings are tiny), but enriching a *large* session can take minutes — and if a single call exceeds the per-request timeout (default 600 s) it fails with `TimedOut`. If you hit that: raise it with `C0_ENRICH_TIMEOUT_SECS`, do less per call (`C0_ENRICH_MAX_CONCEPTS`, `C0_ENRICH_TEXT_BUDGET`, or a smaller `--limit`), or use a faster/smaller model. And if you schedule several LLM jobs (enrich, extract, the reflector), serialize them — e.g. wrap each in a shared `flock` — so they don't dogpile Ollama's single-threaded queue, where a *waiting* request still burns its timeout.
+
 ## Using c0 with Claude Code
 
 c0 pays off most when you treat the **graph as where knowledge lives** and keep your `CLAUDE.md` for **protocol** — the instruction to consult c0, plus your own house rules. Project facts, API shapes, and architecture decisions go stale fast and bloat every prompt when hard-coded into `CLAUDE.md`; put them in the graph instead and let the model pull the relevant subgraph on demand, then *correct* it over time with patches and supersessions.

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1449,6 +1449,13 @@ fn enrichment_max_concepts() -> usize {
         .unwrap_or(DEFAULT_MAX_CONCEPTS_PER_SESSION)
 }
 
+fn enrichment_ollama_timeout_secs() -> u64 {
+    std::env::var("C0_ENRICH_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(ENRICHMENT_OLLAMA_TIMEOUT_SECS)
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct EnrichStats {
     pub sessions_enriched: u32,
@@ -1479,7 +1486,7 @@ async fn extract_session_concepts_ollama(
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(
-            ENRICHMENT_OLLAMA_TIMEOUT_SECS,
+            enrichment_ollama_timeout_secs(),
         ))
         .connect_timeout(std::time::Duration::from_secs(10))
         .build()?;


### PR DESCRIPTION
## Summary

The per-request Ollama timeout for session enrichment was a hardcoded `const ENRICHMENT_OLLAMA_TIMEOUT_SECS = 600` (`src/sessions.rs`). On **slow / CPU-only Ollama hosts** — exactly the "runs on modest hardware" audience the README targets — a single large-session enrichment can take longer than 600 s, fail with `TimedOut`, and there's no way to extend it without recompiling.

This adds a **`C0_ENRICH_TIMEOUT_SECS`** env override (default unchanged at 600), matching the file's existing `C0_ENRICH_TEXT_BUDGET` / `C0_ENRICH_MAX_CONCEPTS` helper idiom — so it's a one-line config, not a new mechanism.

## Changes
- **`src/sessions.rs`** — `enrichment_ollama_timeout_secs()` helper reading `C0_ENRICH_TIMEOUT_SECS`, used at the enrichment request's `.timeout(...)`. The const remains as the default.
- **`README.md`** — a "Running locally" caveat: on a slow CPU, large-session enrichment can hit the timeout; mitigate via `C0_ENRICH_TIMEOUT_SECS`, smaller `--limit` / `C0_ENRICH_*` budgets, or a faster model — plus a note to serialize concurrent LLM jobs so they don't dogpile Ollama's single-threaded queue (where a *waiting* request still burns its timeout).

## Verification
- `cargo build` and `cargo build --features sessions` both succeed; the new helper is used, so it adds no warnings (the 12 existing warnings are pre-existing dead-code in `graph.rs`).
- Default behavior is identical (600 s) unless `C0_ENRICH_TIMEOUT_SECS` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)