### PR TITLE
feat(sessions): make enrichment Ollama timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ The heavier work is **optional and runs in the background**. The reflection loop
 
 The short version: the embedding hot path is light enough for any laptop, and the only reason to add a GPU is to make the *optional* local LLM work faster — never to make c0 usable in the first place.
 
+> **On a slow CPU-only host, watch the enrichment timeout.** Recall stays fast (embeddings are tiny), but enriching a *large* session can take minutes — and if a single call exceeds the per-request timeout (default 600 s) it fails with `TimedOut`. If you hit that: raise it with `C0_ENRICH_TIMEOUT_SECS`, do less per call (`C0_ENRICH_MAX_CONCEPTS`, `C0_ENRICH_TEXT_BUDGET`, or a smaller `--limit`), or use a faster/smaller model. And if you schedule several LLM jobs (enrich, extract, the reflector), serialize them — e.g. wrap each in a shared `flock` — so they don't dogpile Ollama's single-threaded queue, where a *waiting* request still burns its timeout.
+
 ## Using c0 with Claude Code
 
 c0 pays off most when you treat the **graph as where knowledge lives** and keep your `CLAUDE.md` for **protocol** — the instruction to consult c0, plus your own house rules. Project facts, API shapes, and architecture decisions go stale fast and bloat every prompt when hard-coded into `CLAUDE.md`; put them in the graph instead and let the model pull the relevant subgraph on demand, then *correct* it over time with patches and supersessions.

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1449,6 +1449,13 @@ fn enrichment_max_concepts() -> usize {
         .unwrap_or(DEFAULT_MAX_CONCEPTS_PER_SESSION)
 }
 
+fn enrichment_ollama_timeout_secs() -> u64 {
+    std::env::var("C0_ENRICH_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(ENRICHMENT_OLLAMA_TIMEOUT_SECS)
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct EnrichStats {
     pub sessions_enriched: u32,
@@ -1479,7 +1486,7 @@ async fn extract_session_concepts_ollama(
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(
-            ENRICHMENT_OLLAMA_TIMEOUT_SECS,
+            enrichment_ollama_timeout_secs(),
         ))
         .connect_timeout(std::time::Duration::from_secs(10))
         .build()?;


### PR DESCRIPTION
The per-request Ollama timeout for session enrichment was hardcoded at 600s. On slow / CPU-only Ollama hosts, a single large-session enrichment can exceed that and fail with TimedOut — with no way to extend it short of recompiling. Add a `C0_ENRICH_TIMEOUT_SECS` env override (default 600), matching the existing `C0_ENRICH_TEXT_BUDGET` / `C0_ENRICH_MAX_CONCEPTS` helpers.

Also document the slow-CPU enrichment-timeout failure mode and its knobs (plus a note to serialize concurrent LLM jobs) in the "Running locally" section, which the hardcoded timeout otherwise quietly contradicts.

## What & why

<!-- What does this change do, and why? Link any related issue (#123). -->

## Checklist

- [ ] `cargo build` and `cargo build --features sessions` both pass
- [ ] `cargo test --all-features` passes
- [ ] `cargo fmt --all` applied and `cargo clippy --all-features` is clean
- [ ] Docs/README updated if behavior or commands changed
