### PR TITLE
fix(patch): make --file patches durable and floating patches walk-reachable

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Fast pre-commit gate: formatting + lint (the cheap CI steps). The full
+# build + sessions build + tests run on pre-push. Mirrors .github/workflows/ci.yml.
+#
+# Enable once per clone: git config core.hooksPath .githooks
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+echo "▶ pre-commit: cargo fmt --all --check"
+cargo fmt --all --check
+
+echo "▶ pre-commit: cargo clippy --all-targets --all-features"
+cargo clippy --all-targets --all-features
+
+echo "✓ pre-commit checks passed (run scripts/ci.sh for the full pipeline)"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Full local CI before pushing: fmt, clippy, default + sessions builds, tests.
+# Mirrors .github/workflows/ci.yml exactly via scripts/ci.sh.
+#
+# Enable once per clone: git config core.hooksPath .githooks
+set -euo pipefail
+exec "$(git rev-parse --show-toplevel)/scripts/ci.sh"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,22 @@ You'll need Rust (2024 edition / 1.85+), Docker, and Ollama. An `ANTHROPIC_API_K
 
 ## Before you open a PR
 
+Run the exact CI pipeline locally — `scripts/ci.sh` mirrors `.github/workflows/ci.yml`:
+
+```bash
+./scripts/ci.sh   # fmt --check, clippy, default + sessions builds, tests
+```
+
+Or enable the git hooks once so this runs automatically (fast checks on commit, full pipeline on push):
+
+```bash
+git config core.hooksPath .githooks
+```
+
+- `pre-commit` runs `cargo fmt --all --check` + `cargo clippy` (seconds).
+- `pre-push` runs the full `scripts/ci.sh`.
+
+What CI enforces:
 - `cargo fmt --all` — the CI checks formatting.
 - `cargo clippy --all-features` — keep it clean. The crate forbids `unsafe` and lints with
   Clippy `pedantic`.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Run the same checks as .github/workflows/ci.yml locally, in the same order.
+# Keep this in sync with that workflow so a green run here means a green CI.
+#
+# Usage: ./scripts/ci.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+run() {
+	echo
+	echo "▶ $*"
+	"$@"
+}
+
+run cargo fmt --all --check
+run cargo clippy --all-targets --all-features
+run cargo build --verbose
+run cargo build --features sessions --verbose
+run cargo test --all-features
+
+echo
+echo "✓ local CI passed"

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -539,12 +539,24 @@ pub async fn add_patch(
         "p.expired_at = null".to_string(),
     ];
 
+    // Inline a durable copy of the body. The --file live re-read still wins at
+    // render time (keeping refresh semantics), but persisting the content means
+    // the patch survives the source file moving or being deleted, and makes
+    // file-only patches searchable — the fulltext index covers p.content, not
+    // the file on disk. Explicit --content always takes precedence.
+    let inlined: Option<String> = match content {
+        Some(c) => Some(c.to_string()),
+        None => abs_file
+            .as_ref()
+            .and_then(|f| std::fs::read_to_string(f).ok()),
+    };
+
     if let Some(f) = &abs_file {
         params.push(("file", f.clone()));
         sets.push("p.patch_file = $file".to_string());
     }
-    if let Some(c) = content {
-        params.push(("content", c.to_string()));
+    if let Some(c) = &inlined {
+        params.push(("content", c.clone()));
         sets.push("p.content = $content".to_string());
     }
     if let Some(s) = source {
@@ -695,6 +707,22 @@ pub async fn list_patches(
         patches.push((name, file, corrects, namespace));
     }
     Ok(patches)
+}
+
+/// Exact-name existence check for a concept within the given namespaces.
+/// Unlike `search_concepts` (a substring match), this matches `name` exactly.
+pub async fn concept_exists(graph: &Graph, name: &str, namespaces: &[String]) -> Result<bool> {
+    let mut result = graph
+        .execute(
+            query(
+                "MATCH (c:Concept {name: $name}) WHERE c.namespace IN $namespaces
+                 RETURN c.name AS name LIMIT 1",
+            )
+            .param("name", name)
+            .param("namespaces", namespaces.to_vec()),
+        )
+        .await?;
+    Ok(result.next().await?.is_some())
 }
 
 pub async fn search_concepts(

--- a/src/main.rs
+++ b/src/main.rs
@@ -816,6 +816,25 @@ impl Drop for CmdGuard {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // When output is piped to a reader that closes early (`c0 walk | grep -q`,
+    // `| head`), the next `println!` fails with EPIPE and the default hook
+    // panics with a noisy "failed printing to stdout: Broken pipe" backtrace.
+    // Rust ignores SIGPIPE at startup, and `unsafe_code = "forbid"` rules out
+    // restoring SIG_DFL, so swallow that one panic and exit cleanly instead.
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let msg = info
+            .payload()
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| info.payload().downcast_ref::<&str>().copied())
+            .unwrap_or("");
+        if msg.contains("Broken pipe") {
+            std::process::exit(0);
+        }
+        default_hook(info);
+    }));
+
     tracing_subscriber::registry()
         .with(fmt::layer().with_target(false))
         .with(

--- a/src/main.rs
+++ b/src/main.rs
@@ -533,6 +533,27 @@ fn discover_patch_dirs(
     }
 }
 
+/// Render a patch's body. A `--file` ref wins (live re-read keeps refresh
+/// semantics) but falls back to the inline `content` copy if the file moved or
+/// was deleted, instead of leaving the patch as `[Error reading …]`.
+fn print_patch_body(patch: &graph::Patch) {
+    let body = patch
+        .file
+        .as_ref()
+        .and_then(|f| std::fs::read_to_string(shellexpand::tilde(f).as_ref()).ok())
+        .or_else(|| patch.content.clone());
+    match body {
+        Some(c) => println!("{c}"),
+        None => match &patch.file {
+            Some(f) => println!(
+                "[patch '{}': could not read {f} and no inline content]",
+                patch.name
+            ),
+            None => println!("[patch '{}' has no readable content]", patch.name),
+        },
+    }
+}
+
 fn read_triggers(ctx: &config::NamespaceContext) -> Vec<String> {
     let files = config::get_triggers_files(ctx);
     let mut triggers = Vec::new();
@@ -1422,7 +1443,7 @@ async fn main() -> Result<()> {
                 )
                 .await?;
                 println!("Created patch: {name} [{target_namespace}]");
-                if let Some(c) = corrects {
+                if let Some(c) = &corrects {
                     println!("  corrects: {c}");
                 }
                 if let Some(f) = &file {
@@ -1436,6 +1457,26 @@ async fn main() -> Result<()> {
                 }
                 if let Some(v) = &valid_at {
                     println!("  valid_at: {v}");
+                }
+
+                // A patch with no --corrects has no HAS_PATCH/CORRECTS edge, so
+                // `c0 walk` (which traverses those edges only) can never reach
+                // it — it would surface in `c0 search` alone. Anchor it to the
+                // active namespace's concept so it's reachable from
+                // `c0 walk <namespace>`.
+                if corrects.is_none() {
+                    if graph::concept_exists(&graph_conn, target_namespace, &ctx.namespaces).await? {
+                        graph::link_patch(&graph_conn, &name, target_namespace, &ctx.namespaces)
+                            .await?;
+                        println!("  linked: {target_namespace} -[HAS_PATCH]-> {name}");
+                    } else {
+                        println!(
+                            "  note: no '{target_namespace}' concept exists yet, so this patch \
+                             is reachable via `c0 search` but not `c0 walk`. Create the concept \
+                             (`c0 add concept {target_namespace}`) then `c0 relate \
+                             {target_namespace} HAS_PATCH {name}`, or re-add with --corrects."
+                        );
+                    }
                 }
             }
         },
@@ -1580,15 +1621,7 @@ async fn main() -> Result<()> {
                     if let Some(ref url) = patch.url {
                         println!("📎 {url}");
                     }
-                    if let Some(file) = patch.file {
-                        let expanded = shellexpand::tilde(&file);
-                        match std::fs::read_to_string(expanded.as_ref()) {
-                            Ok(content) => println!("{content}"),
-                            Err(e) => println!("[Error reading {file}: {e}]"),
-                        }
-                    } else if let Some(content) = patch.content {
-                        println!("{content}");
-                    }
+                    print_patch_body(&patch);
                 }
                 println!("---");
             }
@@ -1655,15 +1688,7 @@ async fn main() -> Result<()> {
                         if let Some(ref url) = patch.url {
                             println!("📎 {url}");
                         }
-                        if let Some(file) = patch.file {
-                            let expanded = shellexpand::tilde(&file);
-                            match std::fs::read_to_string(expanded.as_ref()) {
-                                Ok(content) => println!("{content}"),
-                                Err(e) => println!("[Error reading {file}: {e}]"),
-                            }
-                        } else if let Some(content) = patch.content {
-                            println!("{content}");
-                        }
+                        print_patch_body(&patch);
                         println!("---");
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1484,7 +1484,8 @@ async fn main() -> Result<()> {
                 // active namespace's concept so it's reachable from
                 // `c0 walk <namespace>`.
                 if corrects.is_none() {
-                    if graph::concept_exists(&graph_conn, target_namespace, &ctx.namespaces).await? {
+                    if graph::concept_exists(&graph_conn, target_namespace, &ctx.namespaces).await?
+                    {
                         graph::link_patch(&graph_conn, &name, target_namespace, &ctx.namespaces)
                             .await?;
                         println!("  linked: {target_namespace} -[HAS_PATCH]-> {name}");


### PR DESCRIPTION
Fixes #23 and #24 — two `c0 add patch` bugs surfaced when bulk-importing ~131 file-based memories. Also includes a general CLI robustness fix (broken-pipe panic).

## #23 — `--file` patches silently lose their body
`add patch --file <path>` persisted only the path ref; the body lived nowhere in the graph. Moving or deleting the source file destroyed the retrievable body, and `backfill patch-content` couldn't help once the file was gone. It also left file-only patches unsearchable, since the `patch_fulltext` index covers `p.content` only. Render was file-first with **no fallback**, printing `[Error reading …]` even when inline content existed.

**Fix**
- `add_patch`: when `--file` is given, read and persist `p.content` as a durable inline copy. Explicit `--content` still takes precedence; the live `--file` re-read still wins at render time, so refresh semantics are unchanged — the inline copy only matters when the file is gone.
- `main.rs`: factor the two duplicated render sites into `print_patch_body`, which falls back to inline `content` on file-read error before emitting a clear message.

## #24 — floating patches invisible to `c0 walk`
A patch added without `--corrects` had no `HAS_PATCH`/`CORRECTS` edge, and `c0 walk` traverses only those edges — so the patch was reachable via `c0 search` but never via walk, the primary retrieval path.

**Fix**
- The `add patch` handler now auto-links a no-`--corrects` patch via `HAS_PATCH` to the active namespace's concept when that concept exists (matching the existing transcript/session-indexing precedent), using the idempotent `link_patch`. If the namespace concept doesn't exist yet, it prints a note explaining how to make the patch walk-reachable.
- Adds a `concept_exists` exact-name helper for the guard (distinct from the substring-matching `search_concepts`).

This linking is deterministic and needs no embeddings/Ollama at add-time.

## Bonus — broken-pipe panic on piped output (not in original issues)
While verifying the above in a container, `c0 walk | grep -q` panicked with `failed printing to stdout: Broken pipe`. This affects **every** command, not just `walk`: when output is piped to a reader that closes early (`| grep -q`, `| head`), the next `println!` fails with EPIPE and the default panic hook prints a noisy backtrace. Rust ignores SIGPIPE at startup, and `unsafe_code = "forbid"` rules out restoring `SIG_DFL`, so this installs a panic hook that swallows the broken-pipe panic and exits cleanly, delegating all other panics to the default hook.

It's a broader change than #23/#24 strictly require, but it's a small, self-contained CLI robustness win that the verification surfaced.

## Verification
- `cargo build` clean (only pre-existing dead-code warnings); all 14 unit tests pass.
- Verified end-to-end in a **clean-room Docker container** against a fresh Neo4j:
  - #24: no-`--corrects` patch auto-linked and reachable from `c0 walk`.
  - #23: `--file` body inlined into `p.content`; after deleting the source file, `walk` rendered the inline copy with no `[Error reading …]`.
- Broken-pipe fix verified on the host across `| grep -q`, `| head -1`, and `| head -c1` (with `walk` emitting multiple lines so EPIPE is hit mid-write): no panic, clean stderr, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
