### PR TITLE
fix(reflector): apply --force and reason so COMMITted concepts persist

### DIFF
--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -327,9 +327,16 @@ pub fn apply() -> Result<()> {
                 println!("  Reason: {reason}");
             }
 
-            let result = Command::new("c0")
-                .args(["add", "concept", concept])
-                .output();
+            // Pass --force so the fuzzy-duplicate guard in `add concept` can't
+            // silently skip (exit 0 without creating) the concept the classifier
+            // already decided to COMMIT. Pass the reason as the description so the
+            // new node gets an embedding and is actually retrievable.
+            let mut args: Vec<&str> = vec!["add", "concept", concept, "--force"];
+            if !reason.is_empty() {
+                args.push("-d");
+                args.push(reason);
+            }
+            let result = Command::new("c0").args(&args).output();
 
             match result {
                 Ok(output) if output.status.success() => {


### PR DESCRIPTION
## What

Fixes a bug where the reflection loop's commits were silently lost: `c0 reflector apply` reported `→ Created` but the concept was never written to the graph.

## Root cause

`apply()` shelled out to `c0 add concept <name>` **without `--force`**. When `add concept`'s fuzzy-duplicate guard finds a similar existing concept, it prints a hint and **exits 0 without creating the node**. `apply` only checks `status.success()`, so it printed `→ Created`, drained the pending queue, and lost the concept. (It also never passed the classifier's reason as a description, so even when a node was created it had no embedding text and wasn't retrievable.)

## Fix

`apply` now calls `c0 add concept <name> --force -d <reason>`:
- `--force` bypasses the fuzzy-dup guard (the classifier already decided this is a COMMIT), so the node is actually created.
- `-d <reason>` gives the node a description, so it gets an embedding and is retrievable by `walk`/`search`/`find`.

## Testing

Verified end-to-end in an isolated Docker stack (Neo4j + Ollama + a build of this branch), nothing touching a local install:

```
2) OLD path:  c0 add concept "deno-typescript-runtime-sandbox" (no --force)
              -> NOT persisted   (reproduces the bug — apply reported success, concept lost)
3) NEW path:  c0 reflector apply  ->  → Created / Applied 1 concept(s). 0 failed
4) VERIFY:    find -> { name: "deno-typescript-runtime-sandbox",
                        description: "Deno is a secure TS/JS runtime with a permissions sandbox." }
RESULT: PASS — persisted with its description
```

Closes #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
