### PR TITLE
ci: auto-merge in-scope Dependabot PRs after CI passes

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Dependabot auto-merge
+
+# Hands-off dependency updates: when Dependabot opens a PR, enable auto-merge so
+# GitHub squash-merges it *once the required CI checks pass* (branch protection on
+# `main` is the safety gate — nothing lands red). Scope is deliberate:
+#   • cargo patch + minor  -> auto-merge
+#   • github-actions (any) -> auto-merge (action bumps are low-risk)
+#   • cargo major / 0.x semver-breaking -> left open for manual review
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch update metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for in-scope updates
+        if: >-
+          steps.meta.outputs.package-ecosystem == 'github_actions' ||
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What & why

Makes in-scope Dependabot updates **hands-off**. When Dependabot opens a PR, a workflow enables GitHub auto-merge, and the PR squash-merges itself **once the required CI checks pass** — branch protection on `main` is the safety gate, so nothing red can land.

**Scope** (chosen deliberately):
- ✅ cargo **patch + minor** → auto-merge
- ✅ **github-actions** (any) → auto-merge (action bumps are low-risk)
- 🔍 cargo **major** / `0.x` semver-breaking → left open for **manual review**

## Companion settings (already applied to the repo)

- "Allow auto-merge" enabled; "Automatically delete head branches" enabled.
- Branch protection on `main`: requires the `build · test · lint` check (admins can still bypass; no required reviews).
- **After PR #40 merges**, `retrieval eval gate` gets added to the required checks too, so dependency bumps must also pass the live-Neo4j retrieval gate before auto-merging.

## Notes

- The workflow only acts on `dependabot[bot]` PRs; it's a no-op for everything else.
- Major Rust bumps still need a human — the current backlog (`reqwest 0.12→0.13`, `toml 0.8→1.1`) is exactly that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
