### PR TITLE
feat(audit): add `--graph-wide` to enrich for whole-graph orphan sweeps

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -487,6 +487,31 @@ async fn apply_edge(graph: &Graph, edge: &EnrichEdge, run_id: &str) -> Result<bo
     }
 }
 
+/// Every namespace that currently holds at least one live knowledge-orphaned
+/// concept. Backs `--graph-wide`, which sweeps the whole graph instead of just
+/// the caller's context-known namespaces. Concepts with a NULL namespace are
+/// skipped: the per-namespace MATCH can't target them, same as the other paths.
+pub async fn orphan_namespaces(graph: &Graph) -> Result<Vec<String>> {
+    let q = query(
+        r"
+        MATCH (c:Concept)
+        WHERE c.invalid_at IS NULL AND c.expired_at IS NULL
+          AND c.namespace IS NOT NULL AND NOT (c)--(:Concept)
+        RETURN DISTINCT c.namespace AS ns
+        ORDER BY ns
+        ",
+    );
+
+    let mut result = graph.execute(q).await?;
+    let mut namespaces = Vec::new();
+    while let Some(row) = result.next().await? {
+        if let Ok(ns) = row.get::<String>("ns") {
+            namespaces.push(ns);
+        }
+    }
+    Ok(namespaces)
+}
+
 pub async fn enrich(
     graph: &Graph,
     targets: &[String],

--- a/src/main.rs
+++ b/src/main.rs
@@ -515,6 +515,12 @@ enum AuditCommands {
         all: bool,
         #[arg(
             long,
+            help = "Enrich every namespace with orphans across the whole graph (not just known namespaces)",
+            conflicts_with_all = ["all", "namespace"]
+        )]
+        graph_wide: bool,
+        #[arg(
+            long,
             default_value = "0.82",
             help = "Min cosine similarity for same-namespace links"
         )]
@@ -3230,6 +3236,7 @@ async fn main() -> Result<()> {
             AuditCommands::Enrich {
                 namespace,
                 all,
+                graph_wide,
                 same_threshold,
                 cross_threshold,
                 max_links,
@@ -3245,7 +3252,9 @@ async fn main() -> Result<()> {
                     };
                     audit::enrich_rollback(&graph_conn, run, json).await?;
                 } else {
-                    let targets: Vec<String> = if all {
+                    let targets: Vec<String> = if graph_wide {
+                        audit::orphan_namespaces(&graph_conn).await?
+                    } else if all {
                         ctx.namespaces.clone()
                     } else {
                         vec![namespace.unwrap_or_else(|| ctx.namespace.clone())]


### PR DESCRIPTION
## What
Adds a `--graph-wide` flag to `c0 audit enrich`.

## Why
`--all` resolves to *context-known* namespaces (current + `global` + parent chain). On a graph spanning many project namespaces, that leaves orphans elsewhere untouched — in local testing `--all` covered **2** namespaces while the graph had live orphans in **~45**. `--graph-wide` enumerates every namespace that currently holds a live knowledge-orphaned concept and enriches across all of them, matching what an external full-graph sweep would do.

## Details
- New `orphan_namespaces()` helper — `DISTINCT c.namespace` over live orphaned concepts. NULL-namespace nodes are skipped, consistent with the existing per-namespace `MATCH`.
- `--graph-wide` is `conflicts_with_all = [all, namespace]`.
- Read-only `--dry-run` and run-tagged `--rollback` behave unchanged.

Verified against a live graph: `--graph-wide --dry-run` reported 233 orphans across ~45 namespaces vs `--all`'s 2; the conflict guard errors correctly.

Complements #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)