### PR TITLE
Guard relate() against Cypher injection; mark codex/kilo experimental

### DIFF
--- a/src/claude.rs
+++ b/src/claude.rs
@@ -477,6 +477,11 @@ impl LlmClient {
         prompt: &str,
         resume_session: Option<&str>,
     ) -> Result<LlmResponse> {
+        // Deliberately never pass `--auto`: droid defaults to read-only
+        // (no file/system modifications) without it, which is what a
+        // classification/extraction call processing untrusted text needs.
+        // `--auto low|medium|high` or `--skip-permissions-unsafe` would grant
+        // it write/shell access -- do not add them here.
         let mut args = vec![
             "exec".to_string(),
             "--output-format".to_string(),
@@ -519,6 +524,11 @@ impl LlmClient {
         if resume_session.is_some() {
             args.push("resume".to_string());
         }
+        // EXPERIMENTAL provider, not exercised by the maintainer. Relies on
+        // `codex exec` being read-only by default. If you actually use codex,
+        // verify against your installed version whether an explicit
+        // `--sandbox read-only` / `--ask-for-approval never` is needed to keep
+        // this classification/extraction call from touching the filesystem.
 
         if let Some(schema_path) = &schema_path {
             args.push("--output-schema".to_string());
@@ -641,7 +651,18 @@ impl LlmClient {
     }
 
     async fn generate_kilo(&self, prompt: &str) -> Result<LlmResponse> {
-        let args = vec!["--auto".to_string(), prompt.to_string()];
+        // EXPERIMENTAL provider, not exercised by the maintainer. The intent
+        // is to avoid `--auto` (auto-approve all permissions) and instead run
+        // the built-in read-only `plan` agent so this untrusted-text call
+        // can't edit files or run arbitrary shell. The exact `run --agent plan`
+        // invocation is UNVERIFIED against a live kilo install -- if you use
+        // kilo, confirm these flags and the `plan` agent's permissions.
+        let args = vec![
+            "run".to_string(),
+            "--agent".to_string(),
+            "plan".to_string(),
+            prompt.to_string(),
+        ];
 
         let output = self.run_cli(&args, None).await?;
         let stdout = String::from_utf8_lossy(&output.stdout);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -426,6 +426,29 @@ pub async fn get_concepts_without_embeddings(
     Ok(concepts)
 }
 
+/// Neo4j has no way to bind a relationship type as a query parameter, so
+/// `relate` must interpolate `rel_type` into the Cypher text. Restrict it to
+/// a plain Cypher identifier (ASCII letter/underscore start, then
+/// alphanumeric/underscore) before that happens, or a crafted value like
+/// `X]->(n) DETACH DELETE n //` could break out of the relationship-type
+/// position and run arbitrary Cypher.
+fn validate_rel_type(rel_type: &str) -> Result<()> {
+    let mut chars = rel_type.chars();
+    let starts_ok = chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_');
+    let rest_ok = chars.all(|c| c.is_ascii_alphanumeric() || c == '_');
+
+    if !starts_ok || !rest_ok || rel_type.len() > 64 {
+        anyhow::bail!(
+            "Invalid relationship type '{rel_type}': must start with a letter or \
+             underscore, contain only letters, digits, and underscores, and be \
+             64 characters or fewer."
+        );
+    }
+    Ok(())
+}
+
 pub async fn relate(
     graph: &Graph,
     from: &str,
@@ -433,6 +456,8 @@ pub async fn relate(
     to: &str,
     namespaces: &[String],
 ) -> Result<()> {
+    validate_rel_type(rel_type)?;
+
     let cypher = if rel_type == "HAS_PATCH" {
         format!(
             "MATCH (a:Concept {{name: $from}}), (b:KnowledgePatch {{name: $to}}) \
@@ -3844,5 +3869,30 @@ mod tests {
     fn scores_are_clamped_to_one() {
         let fused = reciprocal_rank_fusion("q", &[result("alpha")], &[result("alpha")], 0.4, 60.0);
         assert!(fused.iter().all(|r| r.similarity <= 1.0));
+    }
+
+    #[test]
+    fn validate_rel_type_accepts_normal_names() {
+        for ok in ["USES", "DEPENDS_ON", "HAS_PATCH", "_private", "a", "A1_b2"] {
+            assert!(validate_rel_type(ok).is_ok(), "expected {ok:?} to be valid");
+        }
+    }
+
+    #[test]
+    fn validate_rel_type_rejects_cypher_injection_attempts() {
+        for bad in [
+            "X]->(n) DETACH DELETE n //",
+            "USES) DETACH DELETE (a",
+            "with space",
+            "trailing-dash",
+            "1STARTS_WITH_DIGIT",
+            "",
+            &"A".repeat(65),
+        ] {
+            assert!(
+                validate_rel_type(bad).is_err(),
+                "expected {bad:?} to be rejected"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Reviews and tightens a batch of LLM-provider / graph changes.

- **Cypher injection fix (`src/graph.rs`)** — `relate()` interpolates `rel_type` directly into the Cypher string because Neo4j cannot bind a relationship type as a query parameter. A crafted value (e.g. `X]->(n) DETACH DELETE n //`) could break out of the relationship-type position and run arbitrary Cypher. Adds `validate_rel_type` (Cypher-identifier only: ASCII letter/underscore start, alphanumeric/underscore body, ≤64 chars), called before the query is built. Covered by tests for normal names and injection payloads.

- **codex / kilo marked EXPERIMENTAL (`src/claude.rs`)** — these providers are neither used nor testable by the maintainer, so previously-asserted "verified" hardening claims are walked back to honest, unverified notes:
  - `codex`: reverts the added `--sandbox read-only` / `--ask-for-approval never` flags to prior behavior (codex `exec` is read-only by default).
  - `kilo`: keeps the non-`--auto` `run --agent plan` form (avoids auto-approve-all, a safety regression) but flags the invocation as unverified against a live install.

The `droid` comment and `gemini`/`droid` providers are unchanged.

## Test plan

- `cargo build` — clean (pre-existing pedantic warnings only)
- `cargo test validate_rel_type` — both new tests pass
- pre-commit `cargo fmt --check` + `cargo clippy` passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)