### PR TITLE
fix: SPEC audit P0–P2 correctness, hardening, and walk-quality fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Format check
         run: cargo fmt --all --check
 
+      # The no-unwrap/no-expect policy is denied in Cargo.toml's [lints.clippy],
+      # so clippy now *fails* on a violation instead of emitting an ignored
+      # warning. `-D warnings` is not yet enabled repo-wide (200+ style warnings
+      # remain); tightening that is tracked separately.
       - name: Clippy
         run: cargo clippy --all-targets --all-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "c0"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
 description = "A bi-temporal knowledge-graph memory system for LLMs — hybrid keyword + vector retrieval over Neo4j, with a self-improving reflection loop."
 license = "MIT"
 repository = "https://github.com/douglasjordan2/c0"
@@ -35,8 +36,11 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 unsafe_code = "forbid"
 
 [lints.clippy]
-unwrap_used = "warn"
-expect_used = "warn"
+# Denied so the stated no-unwrap/expect policy actually fails the build (and CI)
+# instead of passing as an ignored warning. Provably-infallible sites (static
+# regexes, const log directives) and test modules carry narrow `#[allow]`s.
+unwrap_used = "deny"
+expect_used = "deny"
 dbg_macro = "warn"
 print_stdout = "allow"
 print_stderr = "allow"

--- a/README.md
+++ b/README.md
@@ -188,6 +188,27 @@ c0 reads connection details from the environment, with a per-namespace `.c0/conf
 
 Embedding host/model (Ollama) default to `http://localhost:11434` and `nomic-embed-text`, and are configurable.
 
+### Security & threat model
+
+The bundled `docker-compose.yml` runs Neo4j with **auth disabled** and binds its ports to
+`127.0.0.1` only. This is fine for the intended default: a **single-user local machine**, where
+the graph is trusted memory for one person.
+
+Be aware of the tradeoff: with auth off, *any* local process or user on the machine can read or
+rewrite the entire memory graph — and because this graph is explicitly positioned to **override the
+model's training data**, poisoning it is high-value. If you share the machine, run untrusted local
+code, or expose Neo4j beyond loopback, enable auth:
+
+```bash
+# Generate a password once and start Neo4j with it
+export NEO4J_AUTH="neo4j/$(openssl rand -hex 16)"
+docker compose up -d
+
+# Point the CLI at the same credentials
+export NEO4J_USER="neo4j"
+export NEO4J_PASSWORD="<the password from NEO4J_AUTH>"
+```
+
 ### Background LLM: local, API, or your Claude subscription
 
 The reflection loop, concept extraction, and session enrichment use a chat LLM. By default that's **local Ollama** — keyless and offline. To use Claude instead, set `[claude]` in `.c0/config.toml` to one of:
@@ -338,7 +359,20 @@ c0 reflector run --interval 15m       # tick more often
 c0 reflector run --no-apply           # classify only; hold COMMITs for human review
 ```
 
-For an always-on, unattended setup, prefer the OS scheduler over a long-lived process — cron and systemd handle restarts and logging for you:
+For an always-on, unattended setup, prefer **discrete scheduled runs** over the long-lived
+`c0 reflector run` loop. A systemd timer (or cron) firing `process` → `apply` each hour avoids clock
+drift, gets journald logging, and — with `OnUnitInactiveSec` — won't stack a new run on top of a
+slow one. Ready-to-edit user units ship in [`scripts/systemd/`](scripts/systemd/):
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp scripts/systemd/c0-reflector.{service,timer} ~/.config/systemd/user/
+# edit the Environment= / ExecStart= paths, then:
+systemctl --user daemon-reload
+systemctl --user enable --now c0-reflector.timer
+```
+
+Cron works too:
 
 ```cron
 # Classify dead ends every hour and auto-commit. Keep a human in the loop?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,13 @@ services:
       - "127.0.0.1:7474:7474"
       - "127.0.0.1:7687:7687"
     environment:
-      - NEO4J_AUTH=none
+      # Defaults to no auth for a single-user localhost dev box (ports are bound
+      # to 127.0.0.1 above). To harden — recommended if other users/processes
+      # share this machine — set NEO4J_AUTH before `docker compose up`, e.g.:
+      #   export NEO4J_AUTH="neo4j/$(openssl rand -hex 16)"
+      # then point the CLI at it with matching NEO4J_USER / NEO4J_PASSWORD.
+      # See the "Security & threat model" section of the README.
+      - NEO4J_AUTH=${NEO4J_AUTH:-none}
     volumes:
       - c0-neo4j-data:/data
 

--- a/scripts/systemd/c0-reflector.service
+++ b/scripts/systemd/c0-reflector.service
@@ -1,0 +1,30 @@
+# c0 reflector — one discrete classify+apply cycle, driven by the paired .timer.
+#
+# This is the recommended deployment model: discrete oneshot runs triggered by a
+# systemd timer, rather than a long-running sleep-loop daemon. Oneshot runs get
+# journald logging, no clock drift, and OnUnitInactiveSec backpressure for free.
+#
+# Install (user units):
+#   mkdir -p ~/.config/systemd/user
+#   cp scripts/systemd/c0-reflector.{service,timer} ~/.config/systemd/user/
+#   # edit the paths below to match your install, then:
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now c0-reflector.timer
+#   systemctl --user list-timers          # confirm it is scheduled
+#   journalctl --user -u c0-reflector -f  # watch it run
+
+[Unit]
+Description=c0 reflector — classify dead-end inbox and apply commits
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# Point these at your environment. c0 must be able to reach Neo4j (and Ollama or
+# the Claude CLI, per your [claude] config).
+Environment=NEO4J_URI=bolt://localhost:7687
+Environment=NEO4J_USER=
+Environment=NEO4J_PASSWORD=
+# %h expands to the user's home dir. Adjust if you installed c0 elsewhere.
+ExecStart=%h/.cargo/bin/c0 reflector process
+ExecStart=%h/.cargo/bin/c0 reflector apply

--- a/scripts/systemd/c0-reflector.timer
+++ b/scripts/systemd/c0-reflector.timer
@@ -1,0 +1,14 @@
+# Fire the c0 reflector hourly, measured from the end of the previous run so a
+# slow cycle can't stack up on the next trigger (OnUnitInactiveSec backpressure).
+# See c0-reflector.service for install instructions.
+
+[Unit]
+Description=Run the c0 reflector hourly
+
+[Timer]
+OnBootSec=5min
+OnUnitInactiveSec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -294,7 +294,15 @@ async fn c0_context(
     // 1. resolve the topic to a concept (exact, then fulltext, then hybrid)
     let mut concept = topic.to_string();
     let mut patches = graph::get_patches_temporal(graph, &concept, &ns, &temporal).await?;
-    let mut connected = graph::traverse_temporal(graph, &concept, depth, &ns, &temporal).await?;
+    let mut connected = graph::traverse_temporal(
+        graph,
+        &concept,
+        depth,
+        &ns,
+        &temporal,
+        graph::WALK_DEFAULT_LIMIT,
+    )
+    .await?;
     let mut desc = graph::get_concept_description(graph, &concept, &ns).await?;
 
     if patches.is_empty() && connected.is_empty() && desc.is_none() {
@@ -313,7 +321,15 @@ async fn c0_context(
             }
         }
         patches = graph::get_patches_temporal(graph, &concept, &ns, &temporal).await?;
-        connected = graph::traverse_temporal(graph, &concept, depth, &ns, &temporal).await?;
+        connected = graph::traverse_temporal(
+            graph,
+            &concept,
+            depth,
+            &ns,
+            &temporal,
+            graph::WALK_DEFAULT_LIMIT,
+        )
+        .await?;
         desc = graph::get_concept_description(graph, &concept, &ns).await?;
     }
 

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -270,14 +270,12 @@ impl LlmClient {
             .map(|s| s == "claude-p")
             .unwrap_or(false);
 
-        let effective_prompt = if via_wrapper && has_schema {
-            format!(
+        let effective_prompt = match json_schema {
+            Some(schema) if via_wrapper => format!(
                 "{prompt}\n\nRespond with ONLY a JSON object matching this schema. \
-                 No prose, no markdown fences, no explanation.\n\nSchema:\n{}",
-                json_schema.unwrap()
-            )
-        } else {
-            prompt.to_string()
+                 No prose, no markdown fences, no explanation.\n\nSchema:\n{schema}"
+            ),
+            _ => prompt.to_string(),
         };
 
         let mut args = Vec::new();
@@ -1219,6 +1217,7 @@ fn parse_session_concepts(raw: &str, max: usize) -> Result<Vec<ExtractedConcept>
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 pub struct OllamaClient {
     host: String,
     model: String,
-    timeout: Duration,
+    client: reqwest::Client,
 }
 
 #[derive(Serialize)]
@@ -22,10 +22,19 @@ struct EmbeddingResponse {
 
 impl OllamaClient {
     pub fn new(host: &str, model: &str, timeout_ms: u64) -> Self {
+        // Build the HTTP client once and reuse it across every `embed()` call so
+        // connection pooling actually kicks in — call sites loop over hundreds of
+        // items (backfill, sessions index, bench seeding). `reqwest::Client` is
+        // `Arc` internally, so cloning `OllamaClient` shares the same pool.
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(timeout_ms))
+            .connect_timeout(Duration::from_secs(10))
+            .build()
+            .unwrap_or_default();
         Self {
             host: host.trim_end_matches('/').to_string(),
             model: model.to_string(),
-            timeout: Duration::from_millis(timeout_ms),
+            client,
         }
     }
 
@@ -43,17 +52,13 @@ impl OllamaClient {
     pub async fn embed(&self, text: &str) -> Result<Vec<f32>> {
         let url = format!("{}/api/embeddings", self.host);
 
-        let client = reqwest::Client::builder()
-            .timeout(self.timeout)
-            .connect_timeout(Duration::from_secs(10))
-            .build()?;
-
         let request = EmbeddingRequest {
             model: &self.model,
             prompt: text,
         };
 
-        let response = client
+        let response = self
+            .client
             .post(&url)
             .json(&request)
             .send()

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -394,6 +394,9 @@ async fn fetch_generic_url(url: &str) -> Result<FetchResult> {
     })
 }
 
+// The regexes below are compile-time constants that cannot fail to parse, so the
+// `expect`s are provably infallible — hence the narrow allow on this function.
+#[allow(clippy::expect_used)]
 fn extract_text_from_html(html: &str) -> String {
     static SCRIPT_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?is)<script[^>]*>.*?</script>").expect("valid regex"));

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -211,34 +211,6 @@ pub async fn ping(graph: &Graph) -> Result<()> {
     Ok(())
 }
 
-pub async fn ensure_event(
-    graph: &Graph,
-    name: &str,
-    reason: Option<&str>,
-    namespace: &str,
-) -> Result<bool> {
-    let mut result = graph
-        .execute(
-            query(
-                "MERGE (e:Event {name: $name, namespace: $namespace})
-             ON CREATE SET e.reason = $reason, e.created_at = datetime()
-             RETURN e.name AS name,
-                    CASE WHEN e.created_at = datetime() THEN true ELSE false END AS created",
-            )
-            .param("name", name)
-            .param("namespace", namespace)
-            .param("reason", reason.unwrap_or("")),
-        )
-        .await?;
-
-    if let Some(row) = result.next().await? {
-        let created: bool = row.get("created").unwrap_or(false);
-        Ok(created)
-    } else {
-        Ok(false)
-    }
-}
-
 pub async fn add_concept(
     graph: &Graph,
     name: &str,
@@ -337,6 +309,32 @@ pub async fn update_concept_description(
             .param("namespace", namespace)
             .param("description", description)
             .param("embedding", embedding_vec),
+        )
+        .await?;
+
+    Ok(result.next().await?.is_some())
+}
+
+/// Update a concept's description without touching its embedding. Used when the
+/// embedding sidecar (Ollama) is unavailable: knowledge capture must not be
+/// blocked by a transient outage — `c0 backfill embeddings` can fill the
+/// embedding in later.
+pub async fn update_concept_description_text_only(
+    graph: &Graph,
+    name: &str,
+    namespace: &str,
+    description: &str,
+) -> Result<bool> {
+    let mut result = graph
+        .execute(
+            query(
+                "MATCH (c:Concept {name: $name, namespace: $namespace})
+             SET c.description = $description, c.updated_at = datetime()
+             RETURN c.name AS name",
+            )
+            .param("name", name)
+            .param("namespace", namespace)
+            .param("description", description),
         )
         .await?;
 
@@ -458,17 +456,19 @@ pub async fn relate(
 ) -> Result<()> {
     validate_rel_type(rel_type)?;
 
+    // Use MERGE, not CREATE: running the same `relate` twice (the normal
+    // hook/script usage mode) must not accrete duplicate edges.
     let cypher = if rel_type == "HAS_PATCH" {
         format!(
             "MATCH (a:Concept {{name: $from}}), (b:KnowledgePatch {{name: $to}}) \
              WHERE a.namespace IN $namespaces AND (b.namespace IS NULL OR b.namespace IN $namespaces) \
-             CREATE (a)-[:{rel_type}]->(b) RETURN count(*) AS created"
+             MERGE (a)-[:{rel_type}]->(b) RETURN count(*) AS created"
         )
     } else {
         format!(
             "MATCH (a:Concept {{name: $from}}), (b:Concept {{name: $to}}) \
              WHERE a.namespace IN $namespaces AND b.namespace IN $namespaces \
-             CREATE (a)-[:{rel_type}]->(b) RETURN count(*) AS created"
+             MERGE (a)-[:{rel_type}]->(b) RETURN count(*) AS created"
         )
     };
     let mut result = graph
@@ -499,25 +499,57 @@ pub async fn relate(
     Ok(())
 }
 
+/// Relationship types that are graph bookkeeping / session plumbing rather than
+/// knowledge, and so must never be traversed by `walk`. Invalidation and
+/// supersession have dedicated chain commands; the rest are session structure
+/// that concepts link into via `MENTIONED_IN` and would otherwise leak the
+/// entire 100k+-node session layer into walk output.
+pub const WALK_DENY_RELS: &[&str] = &[
+    "INVALIDATED_BY",
+    "SUPERSEDES",
+    "MENTIONED_IN",
+    "HAS_TURN",
+    "HAS_TOOL_CALL",
+    "CALLED",
+    "IN_SESSION",
+    "HAS_SESSION",
+];
+
+/// Default cap on the number of related nodes a single walk returns. Overridable
+/// via the `--limit` flag; the unbounded depth-2/3 expansion this replaces was a
+/// latency/memory risk on dense graphs.
+pub const WALK_DEFAULT_LIMIT: i64 = 200;
+
 pub async fn traverse_temporal(
     graph: &Graph,
     start: &str,
     depth: u32,
     namespaces: &[String],
     temporal: &TemporalQuery,
+    limit: i64,
 ) -> Result<Vec<String>> {
     let temporal_clause = temporal.build_and_clause("connected");
 
+    // Constrain the traversal to knowledge labels and exclude bookkeeping edges,
+    // and cap the result set. A bare `-[*1..depth]->(connected)` matches any
+    // label over any relationship type with no cap, which both leaks non-knowledge
+    // nodes into walks and is a latency risk on a dense graph.
     let cypher = format!(
-        "MATCH (start:Concept {{name: $start}})-[*1..{depth}]->(connected) \
-         WHERE start.namespace IN $namespaces AND connected.namespace IN $namespaces{temporal_clause} \
-         RETURN DISTINCT connected.name AS name"
+        "MATCH (start:Concept {{name: $start}})-[rels*1..{depth}]->(connected) \
+         WHERE start.namespace IN $namespaces AND connected.namespace IN $namespaces \
+         AND (connected:Concept OR connected:KnowledgePatch) \
+         AND none(r IN rels WHERE type(r) IN $deny_rels){temporal_clause} \
+         RETURN DISTINCT connected.name AS name \
+         LIMIT $limit"
     );
+    let deny_rels: Vec<String> = WALK_DENY_RELS.iter().map(|s| (*s).to_string()).collect();
     let mut result = graph
         .execute(
             query(&cypher)
                 .param("start", start)
-                .param("namespaces", namespaces.to_vec()),
+                .param("namespaces", namespaces.to_vec())
+                .param("deny_rels", deny_rels)
+                .param("limit", limit),
         )
         .await?;
 
@@ -984,26 +1016,44 @@ pub async fn invalidate_concept(
                 .await?
                 .is_some();
 
-            if !target_exists {
-                ensure_event(graph, by_name, reason, namespace).await?;
-            }
-
-            graph
-                .run(
-                    query(
-                        "MATCH (c:Concept {name: $name, namespace: $namespace})
+            if target_exists {
+                // The attribution target is a real node — link to it so the
+                // causal audit trail is traversable.
+                graph
+                    .run(
+                        query(
+                            "MATCH (c:Concept {name: $name, namespace: $namespace})
                      MATCH (target)
                      WHERE target.name = $by_name
                        AND (target:Concept OR target:Event OR target:KnowledgePatch)
                        AND (target.namespace IN $namespaces OR target.namespace IS NULL)
                      MERGE (c)-[:INVALIDATED_BY]->(target)",
+                        )
+                        .param("name", name)
+                        .param("namespace", namespace)
+                        .param("by_name", by_name)
+                        .param("namespaces", namespaces.to_vec()),
                     )
-                    .param("name", name)
-                    .param("namespace", namespace)
-                    .param("by_name", by_name)
-                    .param("namespaces", namespaces.to_vec()),
-                )
-                .await?;
+                    .await?;
+            } else {
+                // The target is freetext that doesn't resolve to an existing
+                // node. Record it as a property on the invalidated node instead
+                // of minting an Event, which would otherwise surface in `walk`
+                // traversals as if it were knowledge.
+                graph
+                    .run(
+                        query(
+                            "MATCH (c:Concept {name: $name, namespace: $namespace})
+                     SET c.invalidated_by_name = $by_name,
+                         c.invalidated_reason = $reason",
+                        )
+                        .param("name", name)
+                        .param("namespace", namespace)
+                        .param("by_name", by_name)
+                        .param("reason", reason.unwrap_or("")),
+                    )
+                    .await?;
+            }
         }
 
         Ok(Some(invalid_at_str))
@@ -1063,27 +1113,42 @@ pub async fn invalidate_patch(
                 .await?
                 .is_some();
 
-            if !target_exists {
-                ensure_event(graph, by_name, reason, namespace).await?;
-            }
-
-            graph
-                .run(
-                    query(
-                        "MATCH (p:KnowledgePatch {name: $name})
+            if target_exists {
+                graph
+                    .run(
+                        query(
+                            "MATCH (p:KnowledgePatch {name: $name})
                      WHERE p.namespace IS NULL OR p.namespace = $namespace
                      MATCH (target)
                      WHERE target.name = $by_name
                        AND (target:Concept OR target:Event OR target:KnowledgePatch)
                        AND (target.namespace IN $namespaces OR target.namespace IS NULL)
                      MERGE (p)-[:INVALIDATED_BY]->(target)",
+                        )
+                        .param("name", name)
+                        .param("namespace", namespace)
+                        .param("by_name", by_name)
+                        .param("namespaces", namespaces.to_vec()),
                     )
-                    .param("name", name)
-                    .param("namespace", namespace)
-                    .param("by_name", by_name)
-                    .param("namespaces", namespaces.to_vec()),
-                )
-                .await?;
+                    .await?;
+            } else {
+                // Unresolved freetext attribution: store on the patch node
+                // instead of minting a walk-polluting Event (see invalidate_concept).
+                graph
+                    .run(
+                        query(
+                            "MATCH (p:KnowledgePatch {name: $name})
+                     WHERE p.namespace IS NULL OR p.namespace = $namespace
+                     SET p.invalidated_by_name = $by_name,
+                         p.invalidated_reason = $reason",
+                        )
+                        .param("name", name)
+                        .param("namespace", namespace)
+                        .param("by_name", by_name)
+                        .param("reason", reason.unwrap_or("")),
+                    )
+                    .await?;
+            }
         }
 
         Ok(Some(invalid_at_str))
@@ -1861,6 +1926,44 @@ pub struct MoveResult {
     pub patches_moved: i64,
     pub old_namespace: String,
     pub new_namespace: String,
+}
+
+/// Relocate a patch to another namespace. Mirrors `move_concept` so a
+/// mis-scoped patch can be fixed in place instead of invalidate-and-recreate
+/// (which litters the graph with bookkeeping). Returns the old namespace on
+/// success, or `None` if no matching patch is found or it is already there.
+/// Patches created before namespacing may have a NULL namespace; those are
+/// treated as belonging to `global`.
+pub async fn move_patch(graph: &Graph, name: &str, to_namespace: &str) -> Result<Option<String>> {
+    let mut result = graph
+        .execute(
+            query(
+                "MATCH (p:KnowledgePatch {name: $name})
+                 WHERE coalesce(p.namespace, 'global') <> $to_namespace
+                 RETURN coalesce(p.namespace, 'global') AS old_namespace",
+            )
+            .param("name", name)
+            .param("to_namespace", to_namespace),
+        )
+        .await?;
+
+    let old_namespace: String = match result.next().await? {
+        Some(row) => row.get("old_namespace").unwrap_or_default(),
+        None => return Ok(None),
+    };
+
+    graph
+        .run(
+            query(
+                "MATCH (p:KnowledgePatch {name: $name})
+                 SET p.namespace = $to_namespace",
+            )
+            .param("name", name)
+            .param("to_namespace", to_namespace),
+        )
+        .await?;
+
+    Ok(Some(old_namespace))
 }
 
 pub async fn move_concept(
@@ -3793,6 +3896,7 @@ pub async fn mark_session_enriched(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,8 @@ enum Commands {
         as_of: Option<String>,
         #[arg(long, help = "Include expired/invalidated knowledge")]
         include_expired: bool,
+        #[arg(long, help = "Max related nodes to return")]
+        limit: Option<i64>,
     },
     Find {
         pattern: String,
@@ -265,6 +267,12 @@ enum AddCommands {
         to: Option<String>,
         #[arg(long, help = "When this knowledge became true (ISO 8601 date)")]
         valid_at: Option<String>,
+        #[arg(
+            long,
+            short = 'q',
+            help = "Suppress the duplicate-suggestion output (for hook/script use)"
+        )]
+        quiet: bool,
     },
     Patch {
         name: String,
@@ -559,6 +567,11 @@ enum MoveCommands {
         to: String,
         #[arg(long, help = "Also move associated patches")]
         with_patches: bool,
+    },
+    Patch {
+        name: String,
+        #[arg(long, help = "Target namespace")]
+        to: String,
     },
     Prefix {
         prefix: String,
@@ -914,12 +927,12 @@ async fn main() -> Result<()> {
         default_hook(info);
     }));
 
+    // "c0=info" is a compile-time-constant directive that cannot fail to parse.
+    #[allow(clippy::expect_used)]
+    let c0_directive = "c0=info".parse().expect("valid directive");
     tracing_subscriber::registry()
         .with(fmt::layer().with_target(false))
-        .with(
-            EnvFilter::from_default_env()
-                .add_directive("c0=info".parse().expect("valid directive")),
-        )
+        .with(EnvFilter::from_default_env().add_directive(c0_directive))
         .init();
 
     let cli = Cli::parse();
@@ -1435,6 +1448,7 @@ async fn main() -> Result<()> {
                 force,
                 to,
                 valid_at,
+                quiet,
             } => {
                 let target_namespace = to.as_ref().unwrap_or(&ctx.namespace);
 
@@ -1458,7 +1472,9 @@ async fn main() -> Result<()> {
                     if let Some(client) = embeddings::OllamaClient::from_config(&semantic_config) {
                         match client.embed(&embed_text).await {
                             Ok(emb) => {
-                                println!("Generated embedding for '{name}'");
+                                if !quiet {
+                                    println!("Generated embedding for '{name}'");
+                                }
                                 Some(emb)
                             }
                             Err(e) => {
@@ -1484,17 +1500,27 @@ async fn main() -> Result<()> {
                     .unwrap_or_default();
 
                     if !similar.is_empty() {
-                        println!("⚠️  Similar concepts already exist:");
-                        for (similar_name, similarity) in &similar {
-                            println!("   - {} ({:.0}% similar)", similar_name, similarity * 100.0);
+                        if !quiet {
+                            println!("⚠️  Similar concepts already exist:");
+                            for (similar_name, similarity) in &similar {
+                                println!(
+                                    "   - {} ({:.0}% similar)",
+                                    similar_name,
+                                    similarity * 100.0
+                                );
+                            }
+                            println!();
+                            println!("Consider:");
+                            if let Some((best_name, _)) = similar.first() {
+                                println!("  c0 relate {name} RELATED_TO {best_name}");
+                            }
+                            println!("  c0 add concept {name} --force  # to create anyway");
                         }
-                        println!();
-                        println!("Consider:");
-                        if let Some((best_name, _)) = similar.first() {
-                            println!("  c0 relate {name} RELATED_TO {best_name}");
-                        }
-                        println!("  c0 add concept {name} --force  # to create anyway");
-                        return Ok(());
+                        // Exit with a distinct non-zero code so callers checking
+                        // `$?` can tell "blocked as duplicate" (2) apart from
+                        // success (0) and hard failure (1). Previously this
+                        // returned Ok, so scripts believed the concept was created.
+                        std::process::exit(2);
                     }
                 }
 
@@ -1629,8 +1655,10 @@ async fn main() -> Result<()> {
             live,
             as_of,
             include_expired,
+            limit,
         } => {
             let timer = Instant::now();
+            let walk_limit = limit.unwrap_or(graph::WALK_DEFAULT_LIMIT);
 
             let temporal = {
                 let mut t = graph::TemporalQuery::default();
@@ -1658,9 +1686,15 @@ async fn main() -> Result<()> {
             let mut patches =
                 graph::get_patches_temporal(&graph_conn, &concept, &ctx.namespaces, &temporal)
                     .await?;
-            let mut connected =
-                graph::traverse_temporal(&graph_conn, &concept, depth, &ctx.namespaces, &temporal)
-                    .await?;
+            let mut connected = graph::traverse_temporal(
+                &graph_conn,
+                &concept,
+                depth,
+                &ctx.namespaces,
+                &temporal,
+                walk_limit,
+            )
+            .await?;
 
             if patches.is_empty() && connected.is_empty() {
                 let ft_matches =
@@ -1695,6 +1729,7 @@ async fn main() -> Result<()> {
                         depth,
                         &ctx.namespaces,
                         &temporal,
+                        walk_limit,
                     )
                     .await?;
                 }
@@ -1740,6 +1775,7 @@ async fn main() -> Result<()> {
                                 depth,
                                 &ctx.namespaces,
                                 &temporal,
+                                walk_limit,
                             )
                             .await?;
                         }
@@ -1897,7 +1933,10 @@ async fn main() -> Result<()> {
         Commands::Find { pattern } => {
             let results = graph::find_pattern(&graph_conn, &pattern).await?;
             if results.is_empty() {
-                log_dead_end("find", &pattern, &ctx.namespace, None);
+                // Don't log `find` misses as knowledge dead-ends: `find` takes raw
+                // Cypher, and a zero-row diagnostic query is usually the desired
+                // outcome, not a missing concept. The classifier would only have to
+                // discard these, burning cycles. `walk` remains the real signal.
                 println!("No matches for pattern");
             } else {
                 println!("Pattern results:");
@@ -2482,29 +2521,56 @@ async fn main() -> Result<()> {
             description,
         } => {
             let semantic_config = config::SemanticConfig::load();
-            let client = if let Some(c) = embeddings::OllamaClient::from_config(&semantic_config) {
-                c
-            } else {
-                eprintln!("Error: Semantic search not configured. Check ~/.c0/config.toml");
-                return Ok(());
+            let client = embeddings::OllamaClient::from_config(&semantic_config);
+
+            // Try to regenerate the embedding, but never let an Ollama outage block
+            // the description write. On failure, persist the text and let
+            // `c0 backfill embeddings` pick up the missing embedding later.
+            let embed_text = format!("{concept}: {description}");
+            let embedding = match &client {
+                Some(c) => match c.embed(&embed_text).await {
+                    Ok(emb) => Some(emb),
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: could not generate embedding ({e}); writing description \
+                             without it. Run `c0 backfill embeddings` once Ollama is back."
+                        );
+                        None
+                    }
+                },
+                None => None,
             };
 
-            let embed_text = format!("{concept}: {description}");
-            let embedding = client.embed(&embed_text).await?;
-
-            let updated = graph::update_concept_description(
-                &graph_conn,
-                &concept,
-                &ctx.namespace,
-                &description,
-                &embedding,
-            )
-            .await?;
+            let updated = match &embedding {
+                Some(emb) => {
+                    graph::update_concept_description(
+                        &graph_conn,
+                        &concept,
+                        &ctx.namespace,
+                        &description,
+                        emb,
+                    )
+                    .await?
+                }
+                None => {
+                    graph::update_concept_description_text_only(
+                        &graph_conn,
+                        &concept,
+                        &ctx.namespace,
+                        &description,
+                    )
+                    .await?
+                }
+            };
 
             if updated {
                 println!("Updated concept: {concept}");
                 println!("  description: {description}");
-                println!("  embedding: regenerated from description");
+                if embedding.is_some() {
+                    println!("  embedding: regenerated from description");
+                } else {
+                    println!("  embedding: skipped (backfill pending)");
+                }
             } else {
                 eprintln!(
                     "Concept '{}' not found in namespace '{}'",
@@ -2715,13 +2781,13 @@ async fn main() -> Result<()> {
                     // guess if that doesn't disambiguate — inlining the wrong
                     // client's data is worse than leaving the patch empty.
                     let ns_seg = format!("/{namespace}/");
-                    let ns_matches: Vec<PathBuf> = cands
+                    let mut ns_matches: Vec<PathBuf> = cands
                         .iter()
                         .filter(|c| c.to_string_lossy().contains(&ns_seg))
                         .cloned()
                         .collect();
-                    match ns_matches.len() {
-                        1 => Resolution::Found(ns_matches.into_iter().next().unwrap()),
+                    match (ns_matches.len(), ns_matches.pop()) {
+                        (1, Some(only)) => Resolution::Found(only),
                         _ => Resolution::Ambiguous(cands),
                     }
                 };
@@ -3291,6 +3357,23 @@ async fn main() -> Result<()> {
                     eprintln!("Concept '{name}' not found or already in namespace '{to}'");
                 }
             },
+            MoveCommands::Patch { name, to } => {
+                if !ctx.namespaces.contains(&to) {
+                    anyhow::bail!(
+                        "'{}' is not in the namespace chain {:?}",
+                        to,
+                        ctx.namespaces
+                    );
+                }
+                match graph::move_patch(&graph_conn, &name, &to).await? {
+                    Some(old) => {
+                        println!("✓ Moved patch: {name} [{old} → {to}]");
+                    }
+                    None => {
+                        eprintln!("Patch '{name}' not found or already in namespace '{to}'");
+                    }
+                }
+            }
             MoveCommands::Prefix {
                 prefix,
                 to,

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -328,15 +328,29 @@ pub fn apply() -> Result<()> {
             }
 
             // Pass --force so the fuzzy-duplicate guard in `add concept` can't
-            // silently skip (exit 0 without creating) the concept the classifier
-            // already decided to COMMIT. Pass the reason as the description so the
-            // new node gets an embedding and is actually retrievable.
-            let mut args: Vec<&str> = vec!["add", "concept", concept, "--force"];
+            // silently skip the concept the classifier already decided to COMMIT.
+            // --quiet suppresses suggestion noise. --source reflector stamps
+            // provenance so the reflector's output can be audited (otherwise it
+            // is indistinguishable from manual adds). Pass the reason as the
+            // description so the new node gets an embedding and is retrievable.
+            let mut args: Vec<&str> = vec![
+                "add",
+                "concept",
+                concept,
+                "--force",
+                "--quiet",
+                "--source",
+                "reflector",
+            ];
             if !reason.is_empty() {
                 args.push("-d");
                 args.push(reason);
             }
-            let result = Command::new("c0").args(&args).output();
+            // Invoke this same binary by absolute path rather than relying on `c0`
+            // being on $PATH — under systemd the daemon's $PATH often lacks the
+            // user's cargo bin dir, which silently breaks every commit.
+            let exe = std::env::current_exe().unwrap_or_else(|_| "c0".into());
+            let result = Command::new(exe).args(&args).output();
 
             match result {
                 Ok(output) if output.status.success() => {


### PR DESCRIPTION
Implements the actionable findings from the code audit (SPEC waves 1–3 plus selected polish). All changes are behavior-compatible **except** #3's exit-code change (called out below for anyone whose hooks/scripts check `$?` on `add concept`).

Verified locally: `cargo fmt`, `cargo build` (default + `sessions`), `cargo clippy --all-targets` (now denies `unwrap_used`/`expect_used` with zero violations), `cargo test` (26 pass). MERGE idempotency and the exit-2 path were also confirmed live against Neo4j.

## Correctness & security (P0)
- **#1 `invalidate --by`** — unresolved freetext attribution is now stored as a property on the invalidated node instead of minting an `Event` that leaked into `walk` output; `ensure_event` removed.
- **#2 `relate()`** — `CREATE` → `MERGE`, so repeated hook/script runs no longer accrete duplicate edges.
- **#3 blocked-as-duplicate** — `add concept` now exits `2` (was `0`) when the fuzzy-duplicate guard blocks a create, so callers can branch on `$?`; adds `--quiet/-q` for hook use. ⚠️ **Behavior change** — scripts checking `$?` will now see `2` instead of `0`.
- **#4 walk traversal** — constrained to `Concept`/`KnowledgePatch` labels, a deny-list for bookkeeping/session relationship types, and a `LIMIT` with a `--limit` escape hatch (default 200). Previously any label over any rel type with no cap.
- **#5 clippy gate** — `unwrap_used`/`expect_used` escalated to **deny** so the stated policy fails the build; the real sites are fixed, provably-infallible statics and test modules carry narrow `#[allow]`s. (Full `-D warnings` not yet enabled — 200+ style warnings remain, tracked separately.)

## Robustness (P1)
- **#7** — `OllamaClient` builds the `reqwest::Client` once and reuses it (connection pooling on hot loops).
- **#8** — `describe` writes the description even when Ollama is down and lets `backfill embeddings` fill the vector later, instead of blocking capture on the sidecar.
- **#9a** — reflector invokes the binary via `current_exe()` instead of `c0` on `$PATH` (fixes silent failures under systemd).
- **#19** — reflector stamps `--source reflector` so its commits are auditable.
- **#20** — `find` no longer logs zero-row Cypher results as knowledge dead-ends.

## Architecture / polish (P2/P3)
- **#14** — new `c0 move patch <name> --to <ns>`, mirroring `move concept`.
- **#6** — `docker-compose` allows a `NEO4J_AUTH` override; README documents the single-user threat model.
- **#22** — ships systemd timer units (`scripts/systemd/`) for discrete reflector runs.
- **#15** — declares `rust-version = "1.85"`.

## Deferred (not in this PR)
The larger structural/credibility items from the audit are intentionally left for follow-up: integration tests (#10), the `main.rs`/`graph.rs` refactors (#11/#12), `find` JSON output (#13), `audit duplicates` (#16), benchmark growth (#17), release hygiene (#18), and the relationship-type vocabulary (#21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
