### PR TITLE
fix(walk): gate fulltext commits on confidence, merge top-3 hybrid entries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1696,42 +1696,55 @@ async fn main() -> Result<()> {
             )
             .await?;
 
+            const FULLTEXT_COMMIT_SCORE: f32 = 50.0;
+            let mut ft_fallback: Option<(String, f32)> = None;
             if patches.is_empty() && connected.is_empty() {
                 let ft_matches =
                     graph::search_concepts_fulltext(&graph_conn, &start, 5, &ctx.namespaces)
                         .await?;
-                let query_terms: Vec<String> =
-                    start.split_whitespace().map(|t| t.to_lowercase()).collect();
-                let best = ft_matches.iter().find(|r| {
-                    let name_lower = r.name.to_lowercase();
-                    let matching = query_terms
+                let query_terms: Vec<String> = start
+                    .split(|c: char| c.is_whitespace() || c == '-')
+                    .filter(|t| !t.is_empty())
+                    .map(str::to_lowercase)
+                    .collect();
+                let term_hits = |name: &str| {
+                    let name_lower = name.to_lowercase();
+                    query_terms
                         .iter()
                         .filter(|t| name_lower.contains(t.as_str()))
-                        .count();
-                    matching > query_terms.len() / 2
-                });
+                        .count()
+                };
+                let best = ft_matches
+                    .iter()
+                    .find(|r| term_hits(&r.name) > query_terms.len() / 2);
                 if let Some(best) = best {
-                    println!(
-                        "(fulltext: '{start}' -> '{}' [score: {:.2}])",
-                        best.name, best.similarity
-                    );
-                    concept = best.name.clone();
-                    patches = graph::get_patches_temporal(
-                        &graph_conn,
-                        &concept,
-                        &ctx.namespaces,
-                        &temporal,
-                    )
-                    .await?;
-                    connected = graph::traverse_temporal(
-                        &graph_conn,
-                        &concept,
-                        depth,
-                        &ctx.namespaces,
-                        &temporal,
-                        walk_limit,
-                    )
-                    .await?;
+                    if term_hits(&best.name) == query_terms.len()
+                        || best.similarity >= FULLTEXT_COMMIT_SCORE
+                    {
+                        println!(
+                            "(fulltext: '{start}' -> '{}' [score: {:.2}])",
+                            best.name, best.similarity
+                        );
+                        concept = best.name.clone();
+                        patches = graph::get_patches_temporal(
+                            &graph_conn,
+                            &concept,
+                            &ctx.namespaces,
+                            &temporal,
+                        )
+                        .await?;
+                        connected = graph::traverse_temporal(
+                            &graph_conn,
+                            &concept,
+                            depth,
+                            &ctx.namespaces,
+                            &temporal,
+                            walk_limit,
+                        )
+                        .await?;
+                    } else {
+                        ft_fallback = Some((best.name.clone(), best.similarity));
+                    }
                 }
             }
 
@@ -1756,30 +1769,85 @@ async fn main() -> Result<()> {
                         .await
                         .unwrap_or_default();
 
+                        const WALK_ENTRY_FANOUT: usize = 3;
                         if let Some((best_name, score)) = similar.first() {
-                            println!(
-                                "(hybrid: '{}' -> '{}' [rrf: {:.6}])",
-                                start, best_name, score
-                            );
                             concept = best_name.clone();
-                            patches = graph::get_patches_temporal(
-                                &graph_conn,
-                                &concept,
-                                &ctx.namespaces,
-                                &temporal,
-                            )
-                            .await?;
-                            connected = graph::traverse_temporal(
-                                &graph_conn,
-                                &concept,
-                                depth,
-                                &ctx.namespaces,
-                                &temporal,
-                                walk_limit,
-                            )
-                            .await?;
+                            let entries: Vec<String> = similar
+                                .iter()
+                                .take(WALK_ENTRY_FANOUT)
+                                .map(|(name, _)| name.clone())
+                                .collect();
+                            if entries.len() > 1 {
+                                println!(
+                                    "(hybrid: '{}' -> '{}' [rrf: {:.6}], +merged: {})",
+                                    start,
+                                    best_name,
+                                    score,
+                                    entries[1..].join(", ")
+                                );
+                            } else {
+                                println!(
+                                    "(hybrid: '{}' -> '{}' [rrf: {:.6}])",
+                                    start, best_name, score
+                                );
+                            }
+                            for entry in &entries {
+                                let entry_patches = graph::get_patches_temporal(
+                                    &graph_conn,
+                                    entry,
+                                    &ctx.namespaces,
+                                    &temporal,
+                                )
+                                .await?;
+                                for patch in entry_patches {
+                                    if !patches.iter().any(|p| {
+                                        p.name == patch.name && p.namespace == patch.namespace
+                                    }) {
+                                        patches.push(patch);
+                                    }
+                                }
+                                let entry_connected = graph::traverse_temporal(
+                                    &graph_conn,
+                                    entry,
+                                    depth,
+                                    &ctx.namespaces,
+                                    &temporal,
+                                    walk_limit,
+                                )
+                                .await?;
+                                for name in entry_connected {
+                                    if !connected.contains(&name) {
+                                        connected.push(name);
+                                    }
+                                }
+                            }
+                            connected.truncate(walk_limit as usize);
                         }
                     }
+                }
+
+                if patches.is_empty()
+                    && connected.is_empty()
+                    && let Some((name, score)) = ft_fallback
+                {
+                    println!("(fulltext-lowconf: '{start}' -> '{name}' [score: {score:.2}])");
+                    concept = name;
+                    patches = graph::get_patches_temporal(
+                        &graph_conn,
+                        &concept,
+                        &ctx.namespaces,
+                        &temporal,
+                    )
+                    .await?;
+                    connected = graph::traverse_temporal(
+                        &graph_conn,
+                        &concept,
+                        depth,
+                        &ctx.namespaces,
+                        &temporal,
+                        walk_limit,
+                    )
+                    .await?;
                 }
             }
 


### PR DESCRIPTION
## Problem

The walk cascade (exact → fulltext → hybrid) commits to the first tier that returns *anything*, not the best answer. The fulltext tier accepted any candidate whose name contained more than half the query terms — with **no score check**. Observed in production use:

```
c0 walk "mobile app development"
(fulltext: 'mobile app development' -> 'mobile-app-backend-api' [score: 17.42])
```

A 2-of-3 partial name match at BM25 score 17 committed, the hybrid tier never ran, and the walk confidently surfaced the wrong subgraph — while hybrid resolved the same query to the right concept. A bad hit is worse than a dead end: dead ends feed the reflector, bad hits are invisible.

## Fix 1 — fulltext confidence gate

Fulltext now commits only when the match is confident:
- **every** query term appears in the node name (terms split on whitespace *and* hyphens), or
- the BM25 score clears `FULLTEXT_COMMIT_SCORE` (50.0).

A score-only threshold was deliberately rejected: BM25 absolute scores are corpus-dependent (an exact name match was observed scoring 31 while a wrong partial match scored 17), so term coverage is the primary signal and the score is an escape hatch. Non-confident matches are held and used only when hybrid is unavailable (embeddings disabled/down) or empty, printed as `(fulltext-lowconf: ...)` — offline behavior degrades gracefully instead of dead-ending.

## Fix 2 — multi-entry walks

The hybrid tier previously walked only the top-1 RRF candidate: winner-take-all entry meant one ambiguous resolution poisoned the entire recall. It now walks the top `WALK_ENTRY_FANOUT` (3) candidates and merges their patches and connections, deduped and capped at the walk limit:

```
(hybrid: 'mobile app dev stack' -> 'mobile-app-development' [rrf: 0.600000], +merged: greenfield-mobile-stack, flutter)
```

## Verification

- `cargo test`: 20/20 pass; pre-commit fmt + clippy clean.
- Live graph regression: exact-name tier-1 walks unchanged; strong fulltext matches (all terms, score ~88) still commit at tier 2; the failing query above now falls through to hybrid and resolves correctly.

## Notes

- Known gap: `eval.rs` scores the ranked *union* across tiers, so no golden currently exercises the commit decision this PR fixes. A follow-up golden should assert that a weak partial fulltext match must not outrank the hybrid answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
