### PR TITLE
fix(walk): let short hyphenated identifiers reach semantic search

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -802,6 +802,14 @@ fn extract_topic(prompt: &str, pattern: &str) -> String {
     }
 }
 
+fn should_use_semantic(query: &str) -> bool {
+    let token_count = query
+        .split(|c: char| c.is_whitespace() || c == '-' || c == '_')
+        .filter(|t| !t.is_empty())
+        .count();
+    query.len() > 10 || query.contains(' ') || token_count > 1
+}
+
 fn get_session_id() -> Option<String> {
     std::env::var("C0_SESSION").ok().or_else(|| {
         dirs::home_dir()
@@ -1749,7 +1757,7 @@ async fn main() -> Result<()> {
             }
 
             if patches.is_empty() && connected.is_empty() {
-                let use_semantic = start.len() > 10 || start.contains(' ');
+                let use_semantic = should_use_semantic(&start);
                 if use_semantic {
                     let semantic_config = config::SemanticConfig::load();
                     if semantic_config.enabled
@@ -3622,4 +3630,36 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_use_semantic;
+
+    #[test]
+    fn short_hyphenated_identifiers_reach_semantic() {
+        assert!(should_use_semantic("voltr-ep3"));
+        assert!(should_use_semantic("voltr-ep6"));
+        assert!(should_use_semantic("c0_walk"));
+    }
+
+    #[test]
+    fn multi_word_and_long_queries_still_reach_semantic() {
+        assert!(should_use_semantic("seo aeo blog publishing"));
+        assert!(should_use_semantic("voltr-ep3-draft1-delivered"));
+        assert!(should_use_semantic("orchestration"));
+    }
+
+    #[test]
+    fn trivial_single_token_queries_stay_gated() {
+        assert!(!should_use_semantic("ep5"));
+        assert!(!should_use_semantic("hypr"));
+        assert!(!should_use_semantic(""));
+    }
+
+    #[test]
+    fn single_token_length_boundary_is_unchanged() {
+        assert!(!should_use_semantic("kubernetes"));
+        assert!(should_use_semantic("kubernetes1"));
+    }
 }


### PR DESCRIPTION
Fixes #57

## The bug

`walk`'s resolution cascade gated its semantic tier on query shape:

```rust
let use_semantic = start.len() > 10 || start.contains(' ');
```

A query that is both short and space-free skipped hybrid search entirely and returned a dead end without ever embedding the query. `voltr-ep3` is 9 characters with no space, so `c0 walk voltr-ep3` dead-ended in ~50ms — too fast for an embedding round-trip, because none happened — while `c0 search voltr-ep3` ranked the correct concept first (BM25 15.6). Same data, different code path.

The fulltext tier above could not cover for it: it commits only when `term_hits(name) > query_terms.len() / 2`, which for a 2-token query requires both tokens in the candidate name.

## The fix

Gate on token count as well, splitting on whitespace/hyphen/underscore exactly as the fulltext tier already does. Extracted into `should_use_semantic` so the boundaries are unit-testable.

Trivially short single-token queries (`ep5`, `hypr`) stay gated, so the original cost-saving intent is preserved — this widens the gate only for genuinely multi-token identifiers.

## Verification

Against a live graph, before and after:

| query | before | after |
|---|---|---|
| `voltr-ep3` | `DEAD_END` | resolves to `voltr-content-series` via hybrid |
| `voltr-ep6` | `DEAD_END` | resolves via hybrid |
| `ep5` | `DEAD_END` | still gated (by design) |
| `hypr` | resolves | resolves (exact match, tier 1) |

Four unit tests cover the multi-token cases, the still-gated trivial cases, and the `len() > 10` boundary so the pre-existing threshold cannot drift unnoticed.

Full suite: 24 passed / 0 failed. `cargo fmt --all --check` and `cargo clippy --all-targets --all-features` clean, plus `cargo build --features sessions`.

## Note

Because `walk` logs dead ends to the reflector inbox, this bug also inflated the dead-end queue with retrieval failures rather than genuine knowledge gaps. Existing queued entries matching this pattern are worth re-checking after the fix.