### PR TITLE
feat(audit): retire expired concepts in search; add `c0 audit dedupe`

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -969,3 +969,241 @@ pub async fn namespaces(
 
     Ok(())
 }
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DedupeMerge {
+    pub name: String,
+    pub duplicate_namespace: String,
+    pub canonical_namespace: String,
+    pub similarity: f32,
+    pub relationships_kept: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DedupeReport {
+    pub run_id: String,
+    pub dry_run: bool,
+    pub threshold: f32,
+    pub merged: Vec<DedupeMerge>,
+    pub held_back: Vec<DedupeMerge>,
+}
+
+async fn propose_merges(
+    graph: &Graph,
+    threshold: f32,
+    namespace: Option<&str>,
+) -> Result<(Vec<DedupeMerge>, Vec<DedupeMerge>)> {
+    let ns_clause = if namespace.is_some() {
+        " AND d.namespace = $namespace"
+    } else {
+        ""
+    };
+    let cypher = format!(
+        r"
+        MATCH (c:Concept {{namespace: 'global'}})
+        WHERE c.embedding IS NOT NULL AND c.expired_at IS NULL
+        MATCH (d:Concept)
+        WHERE d.name = c.name AND d.namespace <> 'global'
+          AND d.embedding IS NOT NULL AND d.expired_at IS NULL{ns_clause}
+        OPTIONAL MATCH (d)-[r]-()
+        RETURN d.name AS name, d.namespace AS dup_ns, c.namespace AS canon_ns,
+               c.embedding AS canon_emb, d.embedding AS dup_emb, count(r) AS rels
+        "
+    );
+    let mut q = query(&cypher);
+    if let Some(ns) = namespace {
+        q = q.param("namespace", ns.to_string());
+    }
+
+    let mut result = graph.execute(q).await?;
+    let (mut merge, mut hold) = (Vec::new(), Vec::new());
+    while let Some(row) = result.next().await? {
+        let canon_emb: Vec<f64> = row.get("canon_emb").unwrap_or_default();
+        let dup_emb: Vec<f64> = row.get("dup_emb").unwrap_or_default();
+        if canon_emb.is_empty() || dup_emb.is_empty() {
+            continue;
+        }
+        let a: Vec<f32> = canon_emb.iter().map(|&x| x as f32).collect();
+        let b: Vec<f32> = dup_emb.iter().map(|&x| x as f32).collect();
+        let entry = DedupeMerge {
+            name: row.get("name").unwrap_or_default(),
+            duplicate_namespace: row.get("dup_ns").unwrap_or_default(),
+            canonical_namespace: row.get("canon_ns").unwrap_or_default(),
+            similarity: cosine_similarity(&a, &b),
+            relationships_kept: row.get("rels").unwrap_or(0),
+        };
+        if entry.similarity >= threshold {
+            merge.push(entry);
+        } else {
+            hold.push(entry);
+        }
+    }
+    merge.sort_by(|x, y| y.similarity.total_cmp(&x.similarity));
+    hold.sort_by(|x, y| x.similarity.total_cmp(&y.similarity));
+    Ok((merge, hold))
+}
+
+async fn apply_merge(graph: &Graph, m: &DedupeMerge, run_id: &str) -> Result<()> {
+    let q = query(
+        r"
+        MATCH (d:Concept {name: $name, namespace: $dup_ns})
+        MATCH (c:Concept {name: $name, namespace: 'global'})
+        SET d.expired_at = datetime(), d.merged_into = c.namespace, d.merge_run = $run
+        MERGE (d)-[r:SAME_AS]->(c)
+        ON CREATE SET r.merge_run = $run
+        RETURN d.name AS name
+        ",
+    )
+    .param("name", m.name.clone())
+    .param("dup_ns", m.duplicate_namespace.clone())
+    .param("run", run_id.to_string());
+    graph.execute(q).await?.next().await?;
+    Ok(())
+}
+
+pub async fn dedupe(
+    graph: &Graph,
+    threshold: f32,
+    namespace: Option<&str>,
+    dry_run: bool,
+    json: bool,
+) -> Result<()> {
+    let run_id = format!(
+        "dedupe-{}-{}",
+        chrono::Utc::now().format("%Y%m%d-%H%M%S"),
+        std::process::id()
+    );
+    let (merges, held) = propose_merges(graph, threshold, namespace).await?;
+
+    if !dry_run {
+        for m in &merges {
+            apply_merge(graph, m, &run_id).await?;
+        }
+    }
+
+    let report = DedupeReport {
+        run_id: run_id.clone(),
+        dry_run,
+        threshold,
+        merged: merges.clone(),
+        held_back: held.clone(),
+    };
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    let title = if dry_run {
+        "C0 Duplicate Merge (dry run)"
+    } else {
+        "C0 Duplicate Merge"
+    };
+    println!("{title}");
+    println!("═══════════════════════════════════════");
+    let kept: i64 = merges.iter().map(|m| m.relationships_kept).sum();
+    println!(
+        "  {} duplicate(s) at or above {:.2} — {} relationship(s) preserved",
+        merges.len(),
+        threshold,
+        kept
+    );
+    println!(
+        "  {} held back below threshold (review by hand)",
+        held.len()
+    );
+    for m in held.iter().take(20) {
+        println!(
+            "    {:.2}  {} [{}]",
+            m.similarity, m.name, m.duplicate_namespace
+        );
+    }
+    println!("═══════════════════════════════════════");
+    if dry_run {
+        println!("Re-run without --dry-run to apply.");
+    } else {
+        println!("Merged {} concept(s), run-id: {run_id}", merges.len());
+        println!("Rollback: c0 audit dedupe --rollback {run_id}");
+    }
+    Ok(())
+}
+
+pub async fn dedupe_rollback(graph: &Graph, run: Option<&str>, json: bool) -> Result<()> {
+    let run_id = match run {
+        Some(r) if !r.is_empty() => r.to_string(),
+        _ => {
+            let q = query(
+                r"
+                MATCH (d:Concept) WHERE d.merge_run IS NOT NULL
+                RETURN d.merge_run AS run ORDER BY run DESC LIMIT 1
+                ",
+            );
+            let mut result = graph.execute(q).await?;
+            match result.next().await? {
+                Some(row) => row.get::<String>("run").unwrap_or_default(),
+                None => {
+                    if json {
+                        println!("{}", serde_json::json!({"restored": 0, "run_id": null}));
+                    } else {
+                        println!("No dedupe runs found.");
+                    }
+                    return Ok(());
+                }
+            }
+        }
+    };
+
+    let q = query(
+        r"
+        MATCH (d:Concept {merge_run: $run})
+        OPTIONAL MATCH (d)-[r:SAME_AS {merge_run: $run}]->()
+        DELETE r
+        SET d.expired_at = null, d.merged_into = null, d.merge_run = null
+        RETURN count(DISTINCT d) AS restored
+        ",
+    )
+    .param("run", run_id.clone());
+    let mut result = graph.execute(q).await?;
+    let restored: i64 = match result.next().await? {
+        Some(row) => row.get("restored").unwrap_or(0),
+        None => 0,
+    };
+
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({"restored": restored, "run_id": run_id})
+        );
+    } else {
+        println!("Restored {restored} concept(s) from run {run_id}.");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod dedupe_tests {
+    use crate::embeddings::cosine_similarity;
+
+    fn normalised(raw: f32) -> f32 {
+        (1.0 + raw) / 2.0
+    }
+
+    #[test]
+    fn default_threshold_matches_neo4j_normalised_085() {
+        assert!((normalised(0.70) - 0.85).abs() < 1e-6);
+    }
+
+    #[test]
+    fn identical_embeddings_score_one() {
+        let v = vec![0.3f32, 0.4, 0.5];
+        assert!((cosine_similarity(&v, &v) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn orthogonal_embeddings_fall_below_default_threshold() {
+        let a = vec![1.0f32, 0.0];
+        let b = vec![0.0f32, 1.0];
+        assert!(cosine_similarity(&a, &b) < 0.70);
+    }
+}

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1043,7 +1043,12 @@ async fn propose_merges(
     Ok((merge, hold))
 }
 
-async fn apply_merge(graph: &Graph, m: &DedupeMerge, run_id: &str) -> Result<()> {
+async fn apply_merge(
+    graph: &Graph,
+    m: &DedupeMerge,
+    run_id: &str,
+    adopted: Option<(&str, Vec<f32>)>,
+) -> Result<()> {
     let q = query(
         r"
         MATCH (d:Concept {name: $name, namespace: $dup_ns})
@@ -1058,7 +1063,49 @@ async fn apply_merge(graph: &Graph, m: &DedupeMerge, run_id: &str) -> Result<()>
     .param("dup_ns", m.duplicate_namespace.clone())
     .param("run", run_id.to_string());
     graph.execute(q).await?.next().await?;
+
+    if let Some((description, embedding)) = adopted {
+        let embedding_vec: Vec<f64> = embedding.iter().map(|&x| f64::from(x)).collect();
+        let q = query(
+            r"
+            MATCH (c:Concept {name: $name, namespace: 'global'})
+            WHERE c.merge_prev_description IS NULL
+            SET c.merge_prev_description = c.description,
+                c.merge_desc_run = $run,
+                c.description = $description,
+                c.embedding = $embedding,
+                c.updated_at = datetime()
+            RETURN c.name AS name
+            ",
+        )
+        .param("name", m.name.clone())
+        .param("run", run_id.to_string())
+        .param("description", description.to_string())
+        .param("embedding", embedding_vec);
+        graph.execute(q).await?.next().await?;
+    }
     Ok(())
+}
+
+async fn better_description(graph: &Graph, m: &DedupeMerge) -> Result<Option<String>> {
+    let q = query(
+        r"
+        MATCH (d:Concept {name: $name, namespace: $dup_ns})
+        MATCH (c:Concept {name: $name, namespace: 'global'})
+        RETURN coalesce(d.description, '') AS dup, coalesce(c.description, '') AS canon
+        ",
+    )
+    .param("name", m.name.clone())
+    .param("dup_ns", m.duplicate_namespace.clone());
+    let mut result = graph.execute(q).await?;
+    match result.next().await? {
+        Some(row) => {
+            let dup: String = row.get("dup").unwrap_or_default();
+            let canon: String = row.get("canon").unwrap_or_default();
+            Ok((dup.len() > canon.len()).then_some(dup))
+        }
+        None => Ok(None),
+    }
 }
 
 pub async fn dedupe(
@@ -1066,6 +1113,7 @@ pub async fn dedupe(
     threshold: f32,
     namespace: Option<&str>,
     dry_run: bool,
+    adopt: Option<&crate::embeddings::OllamaClient>,
     json: bool,
 ) -> Result<()> {
     let run_id = format!(
@@ -1075,9 +1123,21 @@ pub async fn dedupe(
     );
     let (merges, held) = propose_merges(graph, threshold, namespace).await?;
 
+    let mut adopted_count = 0usize;
     if !dry_run {
         for m in &merges {
-            apply_merge(graph, m, &run_id).await?;
+            let mut adopted = None;
+            if let Some(client) = adopt
+                && let Some(better) = better_description(graph, m).await?
+                && let Ok(embedding) = client.embed(&better).await
+            {
+                adopted = Some((better, embedding));
+            }
+            let adopted_ref = adopted.as_ref().map(|(d, e)| (d.as_str(), e.clone()));
+            if adopted_ref.is_some() {
+                adopted_count += 1;
+            }
+            apply_merge(graph, m, &run_id, adopted_ref).await?;
         }
     }
 
@@ -1123,6 +1183,9 @@ pub async fn dedupe(
         println!("Re-run without --dry-run to apply.");
     } else {
         println!("Merged {} concept(s), run-id: {run_id}", merges.len());
+        if adopt.is_some() {
+            println!("Adopted {adopted_count} richer description(s) onto the global concept.");
+        }
         println!("Rollback: c0 audit dedupe --rollback {run_id}");
     }
     Ok(())
@@ -1152,6 +1215,18 @@ pub async fn dedupe_rollback(graph: &Graph, run: Option<&str>, json: bool) -> Re
             }
         }
     };
+
+    let q = query(
+        r"
+        MATCH (c:Concept {merge_desc_run: $run})
+        SET c.description = c.merge_prev_description,
+            c.merge_prev_description = null,
+            c.merge_desc_run = null
+        RETURN count(c) AS n
+        ",
+    )
+    .param("run", run_id.clone());
+    graph.execute(q).await?.next().await?;
 
     let q = query(
         r"

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2136,6 +2136,8 @@ pub async fn search_concepts_semantic(
              YIELD node, score
              WHERE node.namespace IN $namespaces
                AND score >= $threshold
+               AND (node.invalid_at IS NULL OR node.invalid_at > datetime())
+               AND (node.expired_at IS NULL OR node.expired_at > datetime())
              RETURN node.name AS name, node.namespace AS namespace,
                     node.description AS description, score AS similarity
              ORDER BY score DESC",
@@ -2216,6 +2218,8 @@ pub async fn search_concepts_fulltext(
                 "CALL db.index.fulltext.queryNodes('concept_fulltext', $query, {limit: $limit})
              YIELD node, score
              WHERE node.namespace IN $namespaces
+               AND (node.invalid_at IS NULL OR node.invalid_at > datetime())
+               AND (node.expired_at IS NULL OR node.expired_at > datetime())
              RETURN node.name AS name, node.namespace AS namespace,
                     node.description AS description, score AS similarity
              ORDER BY score DESC",

--- a/src/main.rs
+++ b/src/main.rs
@@ -515,6 +515,28 @@ enum AuditCommands {
         #[arg(long, help = "Output JSON format")]
         json: bool,
     },
+    /// Collapse duplicate concepts that shadow a global concept of the same name.
+    Dedupe {
+        #[arg(
+            long,
+            default_value = "0.70",
+            help = "Min raw cosine similarity against the global concept to auto-merge. Raw [-1,1], not Neo4j's normalised (1+cos)/2 score"
+        )]
+        threshold: f32,
+        #[arg(long, help = "Only consider duplicates in this namespace")]
+        namespace: Option<String>,
+        #[arg(long, help = "Show proposed merges without writing them")]
+        dry_run: bool,
+        #[arg(
+            long,
+            help = "Restore concepts merged by a run; optionally pass a run-id (default: most recent)",
+            num_args = 0..=1,
+            default_missing_value = ""
+        )]
+        rollback: Option<String>,
+        #[arg(long, help = "Output JSON format")]
+        json: bool,
+    },
     /// Connect orphaned concepts to their nearest semantic neighbours.
     Enrich {
         #[arg(long, help = "Namespace to enrich (defaults to current)")]
@@ -3374,6 +3396,21 @@ async fn main() -> Result<()> {
                     println!();
                 }
                 audit::namespaces(&graph_conn, &ctx.namespaces, false, json).await?;
+            }
+            AuditCommands::Dedupe {
+                threshold,
+                namespace,
+                dry_run,
+                rollback,
+                json,
+            } => {
+                if let Some(run) = rollback {
+                    let run = if run.is_empty() { None } else { Some(run) };
+                    audit::dedupe_rollback(&graph_conn, run.as_deref(), json).await?;
+                } else {
+                    audit::dedupe(&graph_conn, threshold, namespace.as_deref(), dry_run, json)
+                        .await?;
+                }
             }
             AuditCommands::Enrich {
                 namespace,

--- a/src/main.rs
+++ b/src/main.rs
@@ -529,6 +529,11 @@ enum AuditCommands {
         dry_run: bool,
         #[arg(
             long,
+            help = "Adopt the duplicate's description onto the global concept when it is longer, and re-embed"
+        )]
+        adopt_descriptions: bool,
+        #[arg(
+            long,
             help = "Restore concepts merged by a run; optionally pass a run-id (default: most recent)",
             num_args = 0..=1,
             default_missing_value = ""
@@ -3401,6 +3406,7 @@ async fn main() -> Result<()> {
                 threshold,
                 namespace,
                 dry_run,
+                adopt_descriptions,
                 rollback,
                 json,
             } => {
@@ -3408,8 +3414,26 @@ async fn main() -> Result<()> {
                     let run = if run.is_empty() { None } else { Some(run) };
                     audit::dedupe_rollback(&graph_conn, run.as_deref(), json).await?;
                 } else {
-                    audit::dedupe(&graph_conn, threshold, namespace.as_deref(), dry_run, json)
-                        .await?;
+                    let sem_config = config::SemanticConfig::load();
+                    let client = if adopt_descriptions {
+                        embeddings::OllamaClient::from_config(&sem_config)
+                    } else {
+                        None
+                    };
+                    if adopt_descriptions && client.is_none() {
+                        anyhow::bail!(
+                            "--adopt-descriptions needs Ollama, which is not configured or reachable"
+                        );
+                    }
+                    audit::dedupe(
+                        &graph_conn,
+                        threshold,
+                        namespace.as_deref(),
+                        dry_run,
+                        client.as_ref(),
+                        json,
+                    )
+                    .await?;
                 }
             }
             AuditCommands::Enrich {


### PR DESCRIPTION
Fixes #62
Fixes #63

Two changes, the first a prerequisite for the second.

## 1. Expired concepts kept ranking (#62)

`search_concepts_fulltext` and `search_concepts_semantic` filtered only on namespace, so `c0 supersede` never actually retired anything:

```
$ c0 search no-vnc          # superseded by novnc, expired_at 2026-08-01
1.000000   global   no-vnc  <- still #1
```

Both now apply the `invalid_at`/`expired_at` predicate the temporal query builder already emits. After:

```
$ c0 search no-vnc          # gone
$ c0 search novnc
1.000000   global   novnc   <- canonical still ranks
```

`find_similar_concepts` was unaffected — it delegates to the temporal variant.

## 2. `c0 audit dedupe` (#63)

Repeated extraction re-created the same generic concepts per namespace — 644 redundant copies on the graph this was built against.

**Merge, not delete.** Those copies carry 2,512 relationships including `MENTIONED_IN` session provenance. A merge expires the duplicate and links it `SAME_AS` to the global concept, leaving every edge intact. Change 1 is what makes this sufficient: the expired duplicate stops surfacing while staying recoverable.

```
$ c0 audit dedupe --dry-run
  644 duplicate(s) at or above 0.70 — 2512 relationship(s) preserved
  15 held back below threshold (review by hand)
    0.46  elix [solution-architect]
    0.58  CRO [solution-architect]
    0.64  ollama [reserve-padel]
```

The threshold earns its keep — `elix` at 0.46 is genuinely two different things (global: Shopify dunning platform; solution-architect: a client project). Merging those would corrupt both.

`--dry-run` previews, `--rollback <run-id>` restores, mirroring `audit enrich`.

### A note on the threshold scale

The threshold is **raw cosine**, consistent with `audit enrich`. This is deliberately *not* Neo4j's `vector.similarity.cosine`, which normalises to `(1+cos)/2` — the same pair scores 0.46 raw and 0.73 normalised. The 0.70 default equals 0.85 on the normalised scale. The help text states this, and a unit test pins the relationship so the two scales cannot silently drift.

## Verification

37 passed / 0 failed with `--features sessions`. `cargo fmt --all --check` and `cargo clippy --all-targets --all-features` clean, plus `cargo build --features sessions`.