### PR TITLE
fix(graph): route DISCUSSED_IN through the KnowledgePatch branch in relate()

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -447,6 +447,25 @@ fn validate_rel_type(rel_type: &str) -> Result<()> {
     Ok(())
 }
 
+/// Relationship types whose *target* node is a `KnowledgePatch` rather than a
+/// `Concept`. `relate` must MATCH the target with the right label, so these
+/// rel-types take the KnowledgePatch-target Cypher branch. Everything else is
+/// concept -> concept.
+///
+/// - `HAS_PATCH`:    concept -> patch (a concept owns a patch).
+/// - `DISCUSSED_IN`: concept -> patch (a concept was discussed in a transcript
+///   patch; created by extract indexing at `main.rs` ~3088).
+///
+/// Keep this list in sync with any new concept -> patch rel-types; a rel-type
+/// missing here silently matches `(b:Concept)`, finds nothing, and fails with
+/// "source and/or target not found".
+pub const PATCH_TARGET_RELS: &[&str] = &["HAS_PATCH", "DISCUSSED_IN"];
+
+/// True when `rel_type`'s target node is a `KnowledgePatch` (not a `Concept`).
+fn targets_patch(rel_type: &str) -> bool {
+    PATCH_TARGET_RELS.contains(&rel_type)
+}
+
 pub async fn relate(
     graph: &Graph,
     from: &str,
@@ -458,7 +477,7 @@ pub async fn relate(
 
     // Use MERGE, not CREATE: running the same `relate` twice (the normal
     // hook/script usage mode) must not accrete duplicate edges.
-    let cypher = if rel_type == "HAS_PATCH" {
+    let cypher = if targets_patch(rel_type) {
         format!(
             "MATCH (a:Concept {{name: $from}}), (b:KnowledgePatch {{name: $to}}) \
              WHERE a.namespace IN $namespaces AND (b.namespace IS NULL OR b.namespace IN $namespaces) \
@@ -485,7 +504,7 @@ pub async fn relate(
         None => 0,
     };
     if created == 0 {
-        let target_kind = if rel_type == "HAS_PATCH" {
+        let target_kind = if targets_patch(rel_type) {
             "patch"
         } else {
             "concept"
@@ -3996,6 +4015,43 @@ mod tests {
             assert!(
                 validate_rel_type(bad).is_err(),
                 "expected {bad:?} to be rejected"
+            );
+        }
+    }
+
+    // Regression for the DISCUSSED_IN dead-end bug: `relate` selects its Cypher
+    // branch by whether the rel-type targets a KnowledgePatch. Both HAS_PATCH
+    // and DISCUSSED_IN are concept -> patch (see main.rs extract indexing), so
+    // both MUST take the KnowledgePatch-target branch. Before the fix,
+    // DISCUSSED_IN fell through to the (b:Concept) branch, matched nothing, and
+    // errored on every extracted concept.
+    #[test]
+    fn patch_targeting_rels_use_knowledgepatch_branch() {
+        assert!(targets_patch("HAS_PATCH"), "HAS_PATCH targets a patch");
+        assert!(
+            targets_patch("DISCUSSED_IN"),
+            "DISCUSSED_IN targets a patch (concept was discussed in a transcript patch)"
+        );
+    }
+
+    #[test]
+    fn concept_to_concept_rels_do_not_use_patch_branch() {
+        for rel in ["RELATED_TO", "USES", "DEPENDS_ON", "CORRECTS"] {
+            assert!(
+                !targets_patch(rel),
+                "{rel} is concept -> concept and must not take the patch branch"
+            );
+        }
+    }
+
+    // Guard against the two predicates drifting apart: every rel-type declared
+    // as patch-targeting must actually select the patch branch.
+    #[test]
+    fn patch_target_rels_list_matches_predicate() {
+        for rel in PATCH_TARGET_RELS {
+            assert!(
+                targets_patch(rel),
+                "{rel} is in PATCH_TARGET_RELS but targets_patch() returned false"
             );
         }
     }


### PR DESCRIPTION
## Problem

`c0 relate` builds its Cypher by branching on the target node's label: some
rel-types point at a `KnowledgePatch`, the rest at a `Concept`. The branch was
selected with a literal string check, `rel_type == "HAS_PATCH"` — so **only**
`HAS_PATCH` got the `(b:KnowledgePatch)` MATCH.

`DISCUSSED_IN` is also a concept → patch edge (emitted by extract indexing at
`src/main.rs:3088`, `concept → patch`), but it fell into the `else` branch that
MATCHes `(b:Concept)`. That MATCH finds nothing, returns 0 rows, and `relate`
treats 0 rows as failure:

```
Could not create relationship '<c>' -[DISCUSSED_IN]-> '<p>':
the source concept and/or target concept was not found ...
```

So every concept extracted from a transcript failed to link to its patch. In a
fresh graph seeded via extract, this left **0 relationships** — every `c0 walk`
dead-ended.

## Fix

Introduce the set of rel-types whose target is a patch and a small predicate,
then use it at **both** sites that switched on the target label (the Cypher
selector *and* the error-message `target_kind`, which had the same single-string
bug):

```rust
pub const PATCH_TARGET_RELS: &[&str] = &["HAS_PATCH", "DISCUSSED_IN"];
fn targets_patch(rel_type: &str) -> bool { PATCH_TARGET_RELS.contains(&rel_type) }
```

`relate()` is the only generic, label-dispatching write path — every other
`KnowledgePatch` MATCH in the tree (`add_patch`, `link_patch`, audit, export) is
dedicated hardcoded Cypher that doesn't branch on `rel_type`, so this is the
complete fix. `validate_rel_type()` still gates `rel_type` against injection
before it's interpolated; namespace scoping per branch is unchanged.

## Tests

Three unit tests added (pure-logic, no live DB), matching the existing test
style in `graph.rs`:

- `patch_targeting_rels_use_knowledgepatch_branch` — HAS_PATCH **and**
  DISCUSSED_IN select the patch branch (this is the regression guard; it fails
  on `main`).
- `concept_to_concept_rels_do_not_use_patch_branch` — plain concept→concept
  rels don't.
- `patch_target_rels_list_matches_predicate` — keeps the list and the predicate
  from drifting apart.

## Verification

- `cargo build --release --features sessions` — clean.
- `cargo test --features sessions` — 44 passed, 0 failed.
- Live Neo4j end-to-end (throwaway namespace): `c0 relate <c> DISCUSSED_IN <p>`
  now succeeds and the edge lands targeting a `KnowledgePatch` node; idempotent
  under MERGE (two runs → 1 edge). Before the fix the same call errored.

## Note for reviewers (adjacent findings, not in this PR)

While verifying against a seeded graph I confirmed two things worth flagging
separately, to keep this PR tight and focused on the `relate` bug:

1. The connected-map that `c0 walk` traverses comes from concept→concept
   `RELATED_TO` edges, which are produced by `c0 audit enrich` (embedding
   similarity) — not by extract. On a freshly-seeded graph, running
   `c0 audit enrich` is what lights up `walk`. Working as designed; noting it
   for anyone chasing "walk still dead-ends after extract."
2. `c0 walk <concept> -c/--context <namespace>` appears to use the `-c` value
   only for dead-end telemetry, not for the traversal's namespace scoping (that
   comes from the cwd's `.c0` context). Happy to open a separate issue/PR if
   that's a bug rather than intended.
