### PR TITLE
fix(walk): honor --context namespace in traversal, not just telemetry

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -428,6 +428,25 @@ impl NamespaceContext {
             project_type: None,
         }
     }
+
+    /// Build a context targeting an explicitly named namespace, without a `.c0`
+    /// project dir on disk. Mirrors what `detect_namespace` produces for a
+    /// default project (`inherit_global = true`): the search list is the named
+    /// namespace plus a `global` fallback tail. Used by `c0 walk --context <ns>`
+    /// so the flag scopes the traversal instead of being ignored.
+    pub fn for_namespace(namespace: &str) -> Self {
+        let mut namespaces = vec![namespace.to_string()];
+        if namespace != "global" {
+            namespaces.push("global".to_string());
+        }
+        NamespaceContext {
+            namespace: namespace.to_string(),
+            project_dir: None,
+            parent_dirs: Vec::new(),
+            namespaces,
+            project_type: None,
+        }
+    }
 }
 
 pub fn detect_namespace() -> NamespaceContext {
@@ -723,4 +742,30 @@ pub fn get_all_patches_dirs(ctx: &NamespaceContext) -> Vec<PathBuf> {
     }
 
     dirs.into_iter().filter(|d| d.exists()).collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // Regression: `c0 walk <c> -c <ns>` must actually scope the traversal to
+    // <ns>. `for_namespace` builds the same context a `.c0/config.toml` with
+    // `namespace = <ns>` (default `inherit_global = true`) would produce, so the
+    // walk arm can honor -c without requiring the user to cd into a project dir.
+    #[test]
+    fn for_namespace_scopes_to_that_namespace_plus_global() {
+        let ctx = NamespaceContext::for_namespace("work");
+        assert_eq!(ctx.namespace, "work");
+        // default projects inherit_global, so global is a fallback tail.
+        assert_eq!(ctx.namespaces, vec!["work".to_string(), "global".to_string()]);
+    }
+
+    #[test]
+    fn for_namespace_global_is_just_global() {
+        let ctx = NamespaceContext::for_namespace("global");
+        assert_eq!(ctx.namespace, "global");
+        // No duplicate global tail when the target already is global.
+        assert_eq!(ctx.namespaces, vec!["global".to_string()]);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -758,7 +758,10 @@ mod tests {
         let ctx = NamespaceContext::for_namespace("work");
         assert_eq!(ctx.namespace, "work");
         // default projects inherit_global, so global is a fallback tail.
-        assert_eq!(ctx.namespaces, vec!["work".to_string(), "global".to_string()]);
+        assert_eq!(
+            ctx.namespaces,
+            vec!["work".to_string(), "global".to_string()]
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1695,6 +1695,17 @@ async fn main() -> Result<()> {
             let timer = Instant::now();
             let walk_limit = limit.unwrap_or(graph::WALK_DEFAULT_LIMIT);
 
+            // Honor `--context <ns>`: scope the traversal to the named namespace
+            // instead of whatever the cwd resolved to. Without this the flag was
+            // used only for dead-end telemetry and the walk silently searched
+            // the cwd's namespace (default `global`), so `c0 walk <c> -c work`
+            // dead-ended even on a populated `work` graph.
+            let walk_ctx = match context {
+                Some(ref ns) => config::NamespaceContext::for_namespace(ns),
+                None => ctx,
+            };
+            let ctx = &walk_ctx;
+
             let temporal = {
                 let mut t = graph::TemporalQuery::default();
                 if let Some(ref date_str) = as_of {


### PR DESCRIPTION
## Problem

`c0 walk <concept> -c/--context <ns>` accepts the flag but only feeds it to
dead-end telemetry (`log_dead_end`). The traversal itself runs against
`ctx.namespaces`, which is derived from the current directory's `.c0` project
(default `global`). So `c0 walk <c> -c work` searches `global`, not `work`, and
dead-ends even on a fully populated `work` graph — the documented way to target
a namespace silently queries the wrong one.

This is easy to hit in a multi-namespace setup: an agent (or a cron) that runs
`c0 walk` from an arbitrary working directory can't reach a populated namespace
without dropping a `.c0/config.toml` next to itself, even though `-c` looks like
it should do exactly that.

## Fix

Add `NamespaceContext::for_namespace(ns)`, which constructs the same context a
default `.c0/config.toml` would (`namespace = ns`, `inherit_global = true`): the
search list is the named namespace plus a `global` fallback tail. In the walk
command arm, when `--context` is present, shadow `ctx` with that context before
any queries run. Every downstream walk query (patch lookup, traversal, fulltext
fallback, embedding search) then scopes correctly with no other changes.

`global` is special-cased to avoid a duplicate tail (`["global"]`, not
`["global", "global"]`).

## Tests

- `for_namespace_scopes_to_that_namespace_plus_global` — `for_namespace("work")`
  yields namespaces `["work", "global"]`.
- `for_namespace_global_is_just_global` — no duplicate `global` tail.

## Verification

- `cargo build --release --features sessions` — clean.
- `cargo test --features sessions` — all pass (46 incl. the 2 new).
- Live, from a neutral cwd (no `.c0`, resolves to `global`):
  - `c0 walk variant-level-tax-codes -c work` → returns the connected map
    (`tax-code-integration`, `avalara-implementation`, `class-wallet-integration`).
  - same walk **without** `-c` → correctly still dead-ends on `global` (control),
    confirming `-c` is what scopes the traversal now.

## Note

Independent of #68 (the `DISCUSSED_IN` relate fix), though they compound: #68
makes the edges exist; this makes `-c` actually reach them. Rebased on current
`main` so this is a single-commit diff.
