### PR TITLE
feat(claude): add OpenRouter (OpenAI-compatible) LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ provider = "claude-cli"
 binaries = { claude = "claude" }   # path to your `claude` binary
 ```
 
-Either way, you can route **per task** — e.g. local extraction but Claude classification — with `classification_provider`, `extraction_provider`, `enrichment_provider`, and `concept_extraction_provider`. (`droid`, `codex`, and `gemini` are supported as providers too.)
+Either way, you can route **per task** — e.g. local extraction but Claude classification — with `classification_provider`, `extraction_provider`, `enrichment_provider`, and `concept_extraction_provider`. (`droid`, `codex`, `gemini`, and `openrouter` are supported as providers too.)
 
 > **Unattended setups:** the `claude-cli` provider only works where that CLI is **authenticated**. Interactive/desktop use is fine, but a headless `cron`/`systemd` daemon needs the CLI logged in *in that environment* or classification will fail — for always-on servers the API key (`provider = "claude"`) is the robust choice.
 

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -477,12 +477,12 @@ impl LlmClient {
         })
     }
 
-    /// OpenRouter (OpenAI-compatible) chat-completions provider.
+    /// `OpenRouter` (OpenAI-compatible) chat-completions provider.
     ///
-    /// Mirrors `generate_anthropic_api` but talks to OpenRouter's OpenAI-format
+    /// Mirrors `generate_anthropic_api` but talks to `OpenRouter`'s OpenAI-format
     /// endpoint. Structured output uses function/tool-calling with a forced
     /// `structured_output` tool — the same reliable mechanism the Anthropic path
-    /// uses — because plain JSON-mode is inconsistent across OpenRouter models.
+    /// uses — because plain JSON-mode is inconsistent across `OpenRouter` models.
     /// Reads the key from `OPENROUTER_API_KEY` (independent of the Anthropic key).
     async fn generate_openrouter(
         &self,
@@ -972,8 +972,7 @@ fn provider_binary(provider: LlmProvider, binaries: &LlmBinaries) -> String {
         LlmProvider::Codex => binaries.codex.clone(),
         LlmProvider::Kilo => binaries.kilo.clone(),
         LlmProvider::Gemini => binaries.gemini.clone(),
-        LlmProvider::Ollama => String::new(),
-        LlmProvider::OpenRouter => String::new(),
+        LlmProvider::Ollama | LlmProvider::OpenRouter => String::new(),
     }
 }
 
@@ -1376,5 +1375,52 @@ mod tests {
         assert_eq!(client.model, "sonnet");
         assert_eq!(client.timeout_secs, 120);
         assert_eq!(client.max_budget_usd, config.max_budget_usd);
+    }
+
+    #[test]
+    fn test_openrouter_provider_parses_and_names_correctly() {
+        assert_eq!(LlmProvider::parse("openrouter"), LlmProvider::OpenRouter);
+        assert_eq!(LlmProvider::parse("OpenRouter"), LlmProvider::OpenRouter);
+
+        let binaries = LlmBinaries::default();
+        let client = LlmClient {
+            provider: LlmProvider::OpenRouter,
+            model: "openai/gpt-4o".to_string(),
+            timeout_secs: 60,
+            max_budget_usd: None,
+            binary: binaries.claude,
+            api_key: None,
+            ollama_host: None,
+        };
+        assert_eq!(client.provider_name(), "openrouter");
+    }
+
+    #[tokio::test]
+    async fn test_generate_openrouter_errors_without_api_key() {
+        if std::env::var("OPENROUTER_API_KEY").is_ok() {
+            // Can't safely unset env vars under `unsafe_code = "forbid"`; skip
+            // rather than assert against a key that's actually configured.
+            return;
+        }
+
+        let binaries = LlmBinaries::default();
+        let client = LlmClient {
+            provider: LlmProvider::OpenRouter,
+            model: "openai/gpt-4o".to_string(),
+            timeout_secs: 60,
+            max_budget_usd: None,
+            binary: binaries.claude,
+            api_key: None,
+            ollama_host: None,
+        };
+
+        let err = client
+            .generate_internal("hello", None, None)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("OPENROUTER_API_KEY not set"),
+            "unexpected error message: {err}"
+        );
     }
 }

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -18,6 +18,7 @@ pub enum LlmProvider {
     Kilo,
     Gemini,
     Ollama,
+    OpenRouter,
 }
 
 impl LlmProvider {
@@ -28,6 +29,7 @@ impl LlmProvider {
             "kilo" | "kilocode" => Self::Kilo,
             "gemini" => Self::Gemini,
             "ollama" => Self::Ollama,
+            "openrouter" => Self::OpenRouter,
             "claude-cli" | "claude_cli" | "cli" | "subscription" => Self::ClaudeCli,
             _ => Self::Claude,
         }
@@ -142,6 +144,7 @@ impl LlmClient {
             LlmProvider::Kilo => "kilo",
             LlmProvider::Gemini => "gemini",
             LlmProvider::Ollama => "ollama",
+            LlmProvider::OpenRouter => "openrouter",
         }
     }
 
@@ -173,6 +176,9 @@ impl LlmClient {
                 .generate_claude(prompt, json_schema, resume_session)
                 .await;
         }
+        if matches!(self.provider, LlmProvider::OpenRouter) {
+            return self.generate_openrouter(prompt, json_schema).await;
+        }
         if self.api_key.is_some() && matches!(self.provider, LlmProvider::Claude) {
             return self.generate_anthropic_api(prompt, json_schema).await;
         }
@@ -190,6 +196,7 @@ impl LlmClient {
             LlmProvider::Kilo => self.generate_kilo(prompt).await,
             LlmProvider::Ollama => unreachable!("Ollama handled above"),
             LlmProvider::ClaudeCli => unreachable!("ClaudeCli handled above"),
+            LlmProvider::OpenRouter => unreachable!("OpenRouter handled above"),
         }
     }
 
@@ -457,6 +464,124 @@ impl LlmClient {
                 cache_read,
                 cache_create,
             )
+        });
+
+        Ok(LlmResponse {
+            result: result_text,
+            total_cost_usd: cost,
+            session_id: parsed
+                .get("id")
+                .and_then(|v| v.as_str())
+                .map(std::string::ToString::to_string),
+            is_error: false,
+        })
+    }
+
+    /// OpenRouter (OpenAI-compatible) chat-completions provider.
+    ///
+    /// Mirrors `generate_anthropic_api` but talks to OpenRouter's OpenAI-format
+    /// endpoint. Structured output uses function/tool-calling with a forced
+    /// `structured_output` tool — the same reliable mechanism the Anthropic path
+    /// uses — because plain JSON-mode is inconsistent across OpenRouter models.
+    /// Reads the key from `OPENROUTER_API_KEY` (independent of the Anthropic key).
+    async fn generate_openrouter(
+        &self,
+        prompt: &str,
+        json_schema: Option<&str>,
+    ) -> Result<LlmResponse> {
+        let api_key = std::env::var("OPENROUTER_API_KEY")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| anyhow!("OPENROUTER_API_KEY not set"))?;
+
+        let body = if let Some(schema) = json_schema {
+            let params: serde_json::Value =
+                serde_json::from_str(schema).map_err(|e| anyhow!("Invalid JSON schema: {e}"))?;
+            serde_json::json!({
+                "model": self.model,
+                "max_tokens": 4096,
+                "messages": [{"role": "user", "content": prompt}],
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": "structured_output",
+                        "description": "Return the result in the required structured format.",
+                        "parameters": params,
+                    },
+                }],
+                "tool_choice": {"type": "function", "function": {"name": "structured_output"}},
+            })
+        } else {
+            serde_json::json!({
+                "model": self.model,
+                "max_tokens": 4096,
+                "messages": [{"role": "user", "content": prompt}],
+            })
+        };
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(self.timeout_secs))
+            .connect_timeout(Duration::from_secs(10))
+            .build()?;
+
+        let resp = client
+            .post("https://openrouter.ai/api/v1/chat/completions")
+            .header("Authorization", format!("Bearer {api_key}"))
+            .header("content-type", "application/json")
+            .header("X-Title", "c0")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| anyhow!("OpenRouter API request failed: {e}"))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("OpenRouter API returned {status}: {body_text}");
+        }
+
+        let parsed: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| anyhow!("Failed to parse OpenRouter API response: {e}"))?;
+
+        let message = parsed
+            .get("choices")
+            .and_then(|c| c.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|choice| choice.get("message"));
+
+        let mut result_text = String::new();
+        if let Some(message) = message {
+            // Prefer the forced tool call's arguments (the structured JSON).
+            if let Some(tool_calls) = message.get("tool_calls").and_then(|t| t.as_array())
+                && let Some(first) = tool_calls.first()
+                && let Some(args) = first
+                    .get("function")
+                    .and_then(|f| f.get("arguments"))
+                    .and_then(|a| a.as_str())
+            {
+                result_text = args.to_string();
+            }
+            // Fall back to plain content (non-schema calls, or models that
+            // answer in the content field instead of a tool call).
+            if result_text.is_empty()
+                && let Some(content) = message.get("content").and_then(|c| c.as_str())
+            {
+                result_text = content.to_string();
+            }
+        }
+
+        let cost = parsed.get("usage").and_then(|u| {
+            let input_tokens = u
+                .get("prompt_tokens")
+                .and_then(serde_json::Value::as_f64)
+                .unwrap_or(0.0);
+            let output_tokens = u
+                .get("completion_tokens")
+                .and_then(serde_json::Value::as_f64)
+                .unwrap_or(0.0);
+            estimate_cost_usd(&self.model, input_tokens, output_tokens, 0.0, 0.0)
         });
 
         Ok(LlmResponse {
@@ -848,6 +973,7 @@ fn provider_binary(provider: LlmProvider, binaries: &LlmBinaries) -> String {
         LlmProvider::Kilo => binaries.kilo.clone(),
         LlmProvider::Gemini => binaries.gemini.clone(),
         LlmProvider::Ollama => String::new(),
+        LlmProvider::OpenRouter => String::new(),
     }
 }
 


### PR DESCRIPTION
## What Changed
- Added a new `LlmProvider::OpenRouter` variant with `"openrouter"` config-string parsing and provider-name mapping, wired into `LlmClient::generate_internal` and `provider_binary` dispatch.
- Implemented `generate_openrouter`, which posts to OpenRouter's OpenAI-compatible `chat/completions` endpoint using an `OPENROUTER_API_KEY` env var, uses forced function/tool-calling for structured-output schemas (falling back to plain message content otherwise), and maps usage tokens into an estimated cost.
- Added unit tests covering provider parsing/naming and the no-API-key error path, and updated the README's provider list to mention `openrouter`.

## Risk Assessment

✅ Low: The change is a well-bounded, additive provider implementation that closely mirrors the existing, already-battle-tested generate_anthropic_api path (same request/response shape, same forced tool-calling structured-output mechanism, same error handling via HTTP status + Result), touches no other call sites' behavior, and was verified live per the commit message; the only gap found (cost estimation returning None for OpenRouter models) is a non-blocking observability limitation inherent to lacking third-party pricing data, not a functional defect.

## Testing

Ran the targeted claude:: unit test module after adding two new tests covering the OpenRouter provider addition: LlmProvider::parse(\"openrouter\") / provider_name() mapping, and the real async generate_internal() call erroring with \"OPENROUTER_API_KEY not set\" when the key is absent (the actual guarded code path, not a source-text check). All 4 tests in the module pass. The network-calling portion of generate_openrouter (request construction, forced-tool-call JSON parsing, cost estimation) could not be exercised — the repo has no HTTP-mocking dev-dependency and no OpenRouter API key is available here to call the live endpoint, so that part of the change is unverified by this test pass.

- Outcome: ⚠️ 1 warning across 1 run (4m33s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"27f52f1a5ae285e826a0aa2abefb4dfab5ff2bf7","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `src/claude.rs:952` - estimate_cost_usd() only recognizes hardcoded Anthropic model aliases, so generate_openrouter()&#39;s cost calculation (line 584) always resolves to None for any OpenRouter model id (e.g. &#34;deepseek/deepseek-chat&#34;). Cost logging (log_usage) is silently skipped for every OpenRouter call. This is an inherent limitation (no pricing table exists for third-party OpenRouter models) rather than a bug, so no code change is required for this feature to be correct, but spend visibility for this provider will be blank.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `src/claude.rs:487` - The core new behavior of generate_openrouter() (the HTTP round trip to OpenRouter&#39;s chat-completions endpoint, forced tool-call structured-output parsing, and cost estimation from usage) could not be exercised end-to-end. No HTTP mocking library (wiremock/mockito) exists in this repo&#39;s dev-dependencies, and no OPENROUTER_API_KEY is available in this environment to safely hit the real API. I added focused unit tests for what is safely testable without network access or unsafe env mutation (forbidden by unsafe_code = &#34;forbid&#34; in Cargo.toml): provider string parsing (&#34;openrouter&#34; -&gt; LlmProvider::OpenRouter), provider_name() naming, and the real async code path that returns an error when OPENROUTER_API_KEY is unset. The request-building/response-parsing logic for a live call remains unverified by any test.
- `cargo test --bin c0 claude::tests (4 passed: test_client_creation, test_parse_stream_output, test_openrouter_provider_parses_and_names_correctly, test_generate_openrouter_errors_without_api_key)`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
