### PR TITLE
feat(sessions): ingest Hermes agent sessions via import --from hermes

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Beyond the core commands, c0 includes a few subsystems worth knowing about (full
 
 - **Live sources** — `c0 link source add <name> --url <url>` fetches and embeds a page; `c0 fetch <query>` and `c0 link source search` retrieve over them, so external references stay fresh in the graph.
 - **Triggers** — `c0 trigger add <regex>` (or `--semantic`) decide when a prompt should consult c0; pair one with a [hook](#using-c0-with-claude-code) for hands-off recall.
-- **Sessions** — index your assistant transcripts (build with `--features sessions`), then `c0 sessions search`, `c0 sessions resume`, and track spend with `c0 sessions cost`.
+- **Sessions** — index your assistant transcripts (build with `--features sessions`), then `c0 sessions search`, `c0 sessions resume`, and track spend with `c0 sessions cost`. Pull in another harness's transcripts with `c0 sessions import --from hermes`.
 - **Raw queries & history** — `c0 find "<cypher>"` runs Cypher directly against the graph; `c0 invalidation-chain <name>` reads a concept's causal history.
 - **Maintenance** — `c0 backfill embeddings`, `c0 audit`, `c0 move`, `c0 export`, `c0 status`, `c0 config show`.
 
@@ -335,7 +335,7 @@ If you use [Claude Code](https://claude.com/claude-code), an optional feature in
 cargo install --path . --features sessions
 ```
 
-This is the reference example of c0's **source-adapter** pattern — the same shape any "fill the graph from <source>" integration would take.
+This is the reference example of c0's **source-adapter** pattern — the same shape any "fill the graph from <source>" integration takes. Hermes agent sessions (`~/.hermes/webui/sessions/*.json`) are a second such adapter: `c0 sessions import --from hermes` (add `--force` to re-import unchanged files).
 
 ## The reflection loop — c0's learning engine
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -428,6 +428,17 @@ enum SessionCommands {
         #[arg(long, help = "Skip turns from sidechain (subagent) sessions")]
         skip_sidechains: bool,
     },
+    /// Import sessions from another harness (e.g. Hermes agents) into c0.
+    Import {
+        #[arg(
+            long,
+            default_value = "hermes",
+            help = "Source harness to import from (currently: hermes)"
+        )]
+        from: String,
+        #[arg(long, help = "Re-import even if the session store hasn't changed")]
+        force: bool,
+    },
     Enrich {
         #[arg(
             long,
@@ -1036,6 +1047,19 @@ async fn main() -> Result<()> {
                     sessions::extract_session(&sid, force, skip_sidechains).await?;
                 } else {
                     sessions::extract_all(force, skip_sidechains).await?;
+                }
+                return Ok(());
+            }
+            Some(SessionCommands::Import { from, force }) => {
+                match from.as_str() {
+                    "hermes" => {
+                        sessions::import_hermes_sessions(force).await?;
+                    }
+                    other => {
+                        anyhow::bail!(
+                            "Unknown import source '{other}'. Supported sources: hermes"
+                        );
+                    }
                 }
                 return Ok(());
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1056,9 +1056,7 @@ async fn main() -> Result<()> {
                         sessions::import_hermes_sessions(force).await?;
                     }
                     other => {
-                        anyhow::bail!(
-                            "Unknown import source '{other}'. Supported sources: hermes"
-                        );
+                        anyhow::bail!("Unknown import source '{other}'. Supported sources: hermes");
                     }
                 }
                 return Ok(());

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1177,11 +1177,16 @@ fn resolve_hermes_session_id(doc: &serde_json::Value, path: &Path) -> String {
 fn parse_hermes_session(path: &Path) -> Result<ParsedSession> {
     let content = std::fs::read_to_string(path)?;
     let doc: serde_json::Value = serde_json::from_str(&content)?;
+    Ok(parse_hermes_session_doc(&doc, path))
+}
 
-    let session_id = resolve_hermes_session_id(&doc, path);
+/// Same as `parse_hermes_session`, but for a document already read and
+/// parsed by the caller (avoids a redundant read+parse of the same file).
+fn parse_hermes_session_doc(doc: &serde_json::Value, path: &Path) -> ParsedSession {
+    let session_id = resolve_hermes_session_id(doc, path);
 
-    let workspace = ext_string(&doc, "workspace")
-        .or_else(|| ext_string(&doc, "created_workspace"))
+    let workspace = ext_string(doc, "workspace")
+        .or_else(|| ext_string(doc, "created_workspace"))
         .unwrap_or_default();
     let namespace = if workspace.is_empty() {
         "global".to_string()
@@ -1195,16 +1200,16 @@ fn parse_hermes_session(path: &Path) -> Result<ParsedSession> {
         if t.is_empty() { None } else { Some(t) }
     };
 
-    let doc_model = ext_string(&doc, "model");
+    let doc_model = ext_string(doc, "model");
 
     let mut parsed = ParsedSession {
         session_id: session_id.clone(),
         namespace,
         cwd: workspace.clone(),
-        git_branch: ext_string(&doc, "worktree_branch"),
+        git_branch: ext_string(doc, "worktree_branch"),
         is_sidechain_overall: false,
-        summary: ext_string(&doc, "title"),
-        slug: ext_string(&doc, "title"),
+        summary: ext_string(doc, "title"),
+        slug: ext_string(doc, "title"),
         created_at,
         ended_at,
         ..ParsedSession::default()
@@ -1299,7 +1304,7 @@ fn parse_hermes_session(path: &Path) -> Result<ParsedSession> {
         parsed.first_prompt = "No prompt".to_string();
     }
 
-    Ok(parsed)
+    parsed
 }
 
 async fn embed_text_opt(
@@ -1651,6 +1656,22 @@ pub async fn import_hermes_sessions(force: bool) -> Result<ExtractStats> {
     use std::io::Write;
     for f in &json_files {
         let path = f.path();
+        let filename_key = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        if filename_key.is_empty() {
+            continue;
+        }
+
+        let current_mtime = file_mtime_ms(&path);
+        let stored_mtime = dir_state.sessions.get(&filename_key).copied();
+
+        if !force && stored_mtime == current_mtime && current_mtime.is_some() {
+            stats.sessions_skipped += 1;
+            continue;
+        }
 
         let content = match std::fs::read_to_string(&path) {
             Ok(c) => c,
@@ -1673,42 +1694,25 @@ pub async fn import_hermes_sessions(force: bool) -> Result<ExtractStats> {
             continue;
         }
 
-        let current_mtime = file_mtime_ms(&path);
-        let stored_mtime = dir_state.sessions.get(&session_id).copied();
+        let parsed = parse_hermes_session_doc(&doc, &path);
+        let namespace = parsed.namespace.clone();
+        let n_turns = parsed.turns.len();
+        let n_refl: usize = parsed.turns.iter().map(|t| t.reflections.len()).sum();
+        let n_tc: usize = parsed.turns.iter().map(|t| t.toolcalls.len()).sum();
+        print!("  [{namespace}] {session_id} → {n_turns} turn(s), {n_refl} refl, {n_tc} tc ... ");
+        std::io::stdout().flush().ok();
 
-        if !force && stored_mtime == current_mtime && current_mtime.is_some() {
-            stats.sessions_skipped += 1;
-            continue;
-        }
-
-        match parse_hermes_session(&path) {
-            Ok(parsed) => {
-                let namespace = parsed.namespace.clone();
-                let n_turns = parsed.turns.len();
-                let n_refl: usize = parsed.turns.iter().map(|t| t.reflections.len()).sum();
-                let n_tc: usize = parsed.turns.iter().map(|t| t.toolcalls.len()).sum();
-                print!(
-                    "  [{namespace}] {session_id} → {n_turns} turn(s), {n_refl} refl, {n_tc} tc ... "
-                );
-                std::io::stdout().flush().ok();
-
-                match write_parsed_session(&graph_conn, parsed, ollama.as_ref(), &mut stats).await {
-                    Ok(()) => {
-                        stats.sessions_extracted += 1;
-                        if let Some(m) = current_mtime {
-                            dir_state.sessions.insert(session_id, m);
-                        }
-                        println!("✓");
-                    }
-                    Err(e) => {
-                        stats.errors += 1;
-                        println!("✗ {e}");
-                    }
+        match write_parsed_session(&graph_conn, parsed, ollama.as_ref(), &mut stats).await {
+            Ok(()) => {
+                stats.sessions_extracted += 1;
+                if let Some(m) = current_mtime {
+                    dir_state.sessions.insert(session_id, m);
                 }
+                println!("✓");
             }
             Err(e) => {
                 stats.errors += 1;
-                eprintln!("  parse error for {session_id}: {e}");
+                println!("✗ {e}");
             }
         }
     }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1045,7 +1045,8 @@ fn hermes_timestamp(v: Option<&serde_json::Value>) -> String {
     }
     if let Some(secs) = v.as_f64() {
         let nanos = ((secs.fract()) * 1_000_000_000.0).round() as u32;
-        if let Some(dt) = chrono::DateTime::<chrono::Utc>::from_timestamp(secs.trunc() as i64, nanos)
+        if let Some(dt) =
+            chrono::DateTime::<chrono::Utc>::from_timestamp(secs.trunc() as i64, nanos)
         {
             return dt.to_rfc3339();
         }
@@ -1175,7 +1176,7 @@ struct HermesFileDecision {
 }
 
 /// Resolve a Hermes session file's identity and whether it can be skipped,
-/// using only its path and stat() — no read/parse. The returned
+/// using only its path and `stat()` — no read/parse. The returned
 /// `session_id` is the same key `import_hermes_sessions` stores the mtime
 /// under after processing, so the skip-check lookup and the post-write
 /// store always agree.
@@ -1199,6 +1200,10 @@ fn hermes_dedupe_decision(
 }
 
 /// Parse a Hermes webui session `.json` document into c0's `ParsedSession`.
+/// Production code reads+parses once and calls `parse_hermes_session_doc`
+/// directly (see `import_hermes_sessions`); this path-based wrapper only
+/// remains for tests that don't already have a parsed document in hand.
+#[cfg(test)]
 fn parse_hermes_session(path: &Path) -> Result<ParsedSession> {
     let content = std::fs::read_to_string(path)?;
     let doc: serde_json::Value = serde_json::from_str(&content)?;
@@ -1289,7 +1294,8 @@ fn parse_hermes_session_doc(doc: &serde_json::Value, path: &Path) -> ParsedSessi
 
         // Reasoning → reflection. Hermes stores it as `reasoning_content`
         // (preferred) or `reasoning`, both plain strings.
-        let reasoning = ext_string(msg, "reasoning_content").or_else(|| ext_string(msg, "reasoning"));
+        let reasoning =
+            ext_string(msg, "reasoning_content").or_else(|| ext_string(msg, "reasoning"));
         if let Some(r) = reasoning {
             turn.thinking_chars += r.len() as i64;
             turn.reflections.push(ParsedReflection {
@@ -1645,7 +1651,10 @@ pub async fn extract_all(force: bool, skip_sidechains: bool) -> Result<ExtractSt
 pub async fn import_hermes_sessions(force: bool) -> Result<ExtractStats> {
     let sessions_dir = get_hermes_sessions_dir();
     if !sessions_dir.exists() {
-        println!("No Hermes sessions directory found at {}", sessions_dir.display());
+        println!(
+            "No Hermes sessions directory found at {}",
+            sessions_dir.display()
+        );
         return Ok(ExtractStats::default());
     }
 
@@ -2854,7 +2863,10 @@ mod enrichment_tests {
         assert_eq!(asst.role, "assistant");
         assert_eq!(asst.model.as_deref(), Some("claude-opus-4-8"));
         assert_eq!(asst.reflections.len(), 1);
-        assert_eq!(asst.reflections[0].text, "The user wants help; I'll run a command.");
+        assert_eq!(
+            asst.reflections[0].text,
+            "The user wants help; I'll run a command."
+        );
         assert_eq!(asst.tool_use_count, 2);
         assert_eq!(asst.toolcalls.len(), 2);
         assert_eq!(asst.toolcalls[0].name, "terminal");
@@ -2918,19 +2930,26 @@ mod enrichment_tests {
 
         // Mirror the loop's post-write store step exactly: insert under the
         // decision's own session_id, the same field used for the lookup.
-        dir_state
-            .sessions
-            .insert(first.session_id.clone(), first.current_mtime.expect("mtime"));
+        dir_state.sessions.insert(
+            first.session_id.clone(),
+            first.current_mtime.expect("mtime"),
+        );
 
         let second = hermes_dedupe_decision(&dir_state, &path, false).expect("resolves an id");
         assert_eq!(
             first.session_id, second.session_id,
             "the skip-check lookup key and the post-write store key must be identical"
         );
-        assert!(second.skip, "an unchanged file must be skipped without reading/parsing it");
+        assert!(
+            second.skip,
+            "an unchanged file must be skipped without reading/parsing it"
+        );
 
         let forced = hermes_dedupe_decision(&dir_state, &path, true).expect("resolves an id");
-        assert!(!forced.skip, "force must bypass the skip even when mtime is unchanged");
+        assert!(
+            !forced.skip,
+            "force must bypass the skip even when mtime is unchanged"
+        );
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1158,19 +1158,44 @@ fn bash_call_for_hermes_tool(name: &str, input: &serde_json::Value) -> Option<Ba
     })
 }
 
-/// Resolve the graph identity for a Hermes session document: the document's
-/// own `session_id` field when present, falling back to the file stem.
-/// Used for both the incremental dedupe/skip state key and the Session/Turn
-/// MERGE key, so a file is never tracked under one identity and written to
-/// the graph under another.
-fn resolve_hermes_session_id(doc: &serde_json::Value, path: &Path) -> String {
-    ext_string(doc, "session_id")
-        .or_else(|| {
-            path.file_stem()
-                .and_then(|s| s.to_str())
-                .map(std::string::ToString::to_string)
-        })
-        .unwrap_or_default()
+/// The graph identity for a Hermes session: the file stem, exactly like the
+/// sibling Claude Code path. Used for both the incremental dedupe/skip state
+/// key and the Session/Turn MERGE key.
+fn hermes_file_session_id(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+struct HermesFileDecision {
+    session_id: String,
+    current_mtime: Option<u64>,
+    skip: bool,
+}
+
+/// Resolve a Hermes session file's identity and whether it can be skipped,
+/// using only its path and stat() — no read/parse. The returned
+/// `session_id` is the same key `import_hermes_sessions` stores the mtime
+/// under after processing, so the skip-check lookup and the post-write
+/// store always agree.
+fn hermes_dedupe_decision(
+    dir_state: &TurnsDirState,
+    path: &PathBuf,
+    force: bool,
+) -> Option<HermesFileDecision> {
+    let session_id = hermes_file_session_id(path);
+    if session_id.is_empty() {
+        return None;
+    }
+    let current_mtime = file_mtime_ms(path);
+    let stored_mtime = dir_state.sessions.get(&session_id).copied();
+    let skip = !force && stored_mtime == current_mtime && current_mtime.is_some();
+    Some(HermesFileDecision {
+        session_id,
+        current_mtime,
+        skip,
+    })
 }
 
 /// Parse a Hermes webui session `.json` document into c0's `ParsedSession`.
@@ -1183,7 +1208,7 @@ fn parse_hermes_session(path: &Path) -> Result<ParsedSession> {
 /// Same as `parse_hermes_session`, but for a document already read and
 /// parsed by the caller (avoids a redundant read+parse of the same file).
 fn parse_hermes_session_doc(doc: &serde_json::Value, path: &Path) -> ParsedSession {
-    let session_id = resolve_hermes_session_id(doc, path);
+    let session_id = hermes_file_session_id(path);
 
     let workspace = ext_string(doc, "workspace")
         .or_else(|| ext_string(doc, "created_workspace"))
@@ -1656,22 +1681,15 @@ pub async fn import_hermes_sessions(force: bool) -> Result<ExtractStats> {
     use std::io::Write;
     for f in &json_files {
         let path = f.path();
-        let filename_key = path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("")
-            .to_string();
-        if filename_key.is_empty() {
+        let Some(decision) = hermes_dedupe_decision(dir_state, &path, force) else {
             continue;
-        }
-
-        let current_mtime = file_mtime_ms(&path);
-        let stored_mtime = dir_state.sessions.get(&filename_key).copied();
-
-        if !force && stored_mtime == current_mtime && current_mtime.is_some() {
+        };
+        if decision.skip {
             stats.sessions_skipped += 1;
             continue;
         }
+        let session_id = decision.session_id;
+        let current_mtime = decision.current_mtime;
 
         let content = match std::fs::read_to_string(&path) {
             Ok(c) => c,
@@ -1689,10 +1707,6 @@ pub async fn import_hermes_sessions(force: bool) -> Result<ExtractStats> {
                 continue;
             }
         };
-        let session_id = resolve_hermes_session_id(&doc, &path);
-        if session_id.is_empty() {
-            continue;
-        }
 
         let parsed = parse_hermes_session_doc(&doc, &path);
         let namespace = parsed.namespace.clone();
@@ -2861,14 +2875,12 @@ mod enrichment_tests {
     }
 
     #[test]
-    fn hermes_dedupe_key_matches_graph_identity_on_id_collision() {
-        // Two distinct files (different filenames/mtimes) whose documents
-        // declare the SAME internal session_id. import_hermes_sessions()
-        // must key its incremental skip/dedupe state on the same value
-        // parse_hermes_session() uses as the Session/Turn MERGE key —
-        // otherwise a later file can silently wipe an earlier file's turns
-        // via graph::delete_session_turns() while the state cache still
-        // tracks them under separate, mismatched keys.
+    fn hermes_graph_identity_ignores_colliding_internal_session_id() {
+        // Two distinct files (different filenames) whose documents declare
+        // the SAME internal session_id. The graph identity must come from
+        // the filename, not the document body, so the two files can never
+        // MERGE onto the same Session/Turn node and wipe each other via
+        // graph::delete_session_turns().
         let root = scratch_dir("hermes-id-collision");
         let workspace = root.join("myproj");
         std::fs::create_dir_all(&workspace).expect("create workspace");
@@ -2878,24 +2890,47 @@ mod enrichment_tests {
         std::fs::rename(&path_a, &path_b).expect("rename to distinct filename");
         let path_a = write_hermes_fixture(&root, "dup_session", workspace.to_str().unwrap());
 
+        let identity_a = parse_hermes_session(&path_a).expect("parse a").session_id;
+        let identity_b = parse_hermes_session(&path_b).expect("parse b").session_id;
+
         assert_ne!(
-            path_a.file_stem().and_then(|s| s.to_str()),
-            path_b.file_stem().and_then(|s| s.to_str()),
-            "fixtures must have distinct filenames to exercise the collision"
+            identity_a, identity_b,
+            "files with distinct filenames must never resolve to the same graph identity, \
+             even when their document bodies share an internal session_id"
         );
+        assert_eq!(identity_a, hermes_file_session_id(&path_a));
+        assert_eq!(identity_b, hermes_file_session_id(&path_b));
+        assert_eq!(identity_b, "other_filename");
 
-        for path in [&path_a, &path_b] {
-            let content = std::fs::read_to_string(path).expect("read fixture");
-            let doc: serde_json::Value = serde_json::from_str(&content).expect("parse json");
-            let dedupe_key = resolve_hermes_session_id(&doc, path);
-            let graph_identity = parse_hermes_session(path).expect("parse").session_id;
+        std::fs::remove_dir_all(&root).ok();
+    }
 
-            assert_eq!(
-                dedupe_key, graph_identity,
-                "state key must match the graph MERGE identity for {path:?}"
-            );
-            assert_eq!(dedupe_key, "dup_session");
-        }
+    #[test]
+    fn hermes_dedupe_decision_skip_key_matches_store_key() {
+        let root = scratch_dir("hermes-dedupe-decision");
+        std::fs::create_dir_all(&root).expect("create root");
+        let path = write_hermes_fixture(&root, "sess_dedupe", root.to_str().unwrap());
+
+        let mut dir_state = TurnsDirState::default();
+
+        let first = hermes_dedupe_decision(&dir_state, &path, false).expect("resolves an id");
+        assert!(!first.skip, "a never-seen file must not be skipped");
+
+        // Mirror the loop's post-write store step exactly: insert under the
+        // decision's own session_id, the same field used for the lookup.
+        dir_state
+            .sessions
+            .insert(first.session_id.clone(), first.current_mtime.expect("mtime"));
+
+        let second = hermes_dedupe_decision(&dir_state, &path, false).expect("resolves an id");
+        assert_eq!(
+            first.session_id, second.session_id,
+            "the skip-check lookup key and the post-write store key must be identical"
+        );
+        assert!(second.skip, "an unchanged file must be skipped without reading/parsing it");
+
+        let forced = hermes_dedupe_decision(&dir_state, &path, true).expect("resolves an id");
+        assert!(!forced.skip, "force must bypass the skip even when mtime is unchanged");
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1158,18 +1158,27 @@ fn bash_call_for_hermes_tool(name: &str, input: &serde_json::Value) -> Option<Ba
     })
 }
 
-/// Parse a Hermes webui session `.json` document into c0's `ParsedSession`.
-fn parse_hermes_session(path: &Path) -> Result<ParsedSession> {
-    let content = std::fs::read_to_string(path)?;
-    let doc: serde_json::Value = serde_json::from_str(&content)?;
-
-    let session_id = ext_string(&doc, "session_id")
+/// Resolve the graph identity for a Hermes session document: the document's
+/// own `session_id` field when present, falling back to the file stem.
+/// Used for both the incremental dedupe/skip state key and the Session/Turn
+/// MERGE key, so a file is never tracked under one identity and written to
+/// the graph under another.
+fn resolve_hermes_session_id(doc: &serde_json::Value, path: &Path) -> String {
+    ext_string(doc, "session_id")
         .or_else(|| {
             path.file_stem()
                 .and_then(|s| s.to_str())
                 .map(std::string::ToString::to_string)
         })
-        .unwrap_or_default();
+        .unwrap_or_default()
+}
+
+/// Parse a Hermes webui session `.json` document into c0's `ParsedSession`.
+fn parse_hermes_session(path: &Path) -> Result<ParsedSession> {
+    let content = std::fs::read_to_string(path)?;
+    let doc: serde_json::Value = serde_json::from_str(&content)?;
+
+    let session_id = resolve_hermes_session_id(&doc, path);
 
     let workspace = ext_string(&doc, "workspace")
         .or_else(|| ext_string(&doc, "created_workspace"))
@@ -1642,11 +1651,24 @@ pub async fn import_hermes_sessions(force: bool) -> Result<ExtractStats> {
     use std::io::Write;
     for f in &json_files {
         let path = f.path();
-        let session_id = path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("")
-            .to_string();
+
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                stats.errors += 1;
+                eprintln!("  read error for {}: {e}", path.display());
+                continue;
+            }
+        };
+        let doc: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(d) => d,
+            Err(e) => {
+                stats.errors += 1;
+                eprintln!("  parse error for {}: {e}", path.display());
+                continue;
+            }
+        };
+        let session_id = resolve_hermes_session_id(&doc, &path);
         if session_id.is_empty() {
             continue;
         }
@@ -2830,6 +2852,46 @@ mod enrichment_tests {
 
         // Tool result turn preserved as its own turn.
         assert_eq!(parsed.turns[2].role, "tool");
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn hermes_dedupe_key_matches_graph_identity_on_id_collision() {
+        // Two distinct files (different filenames/mtimes) whose documents
+        // declare the SAME internal session_id. import_hermes_sessions()
+        // must key its incremental skip/dedupe state on the same value
+        // parse_hermes_session() uses as the Session/Turn MERGE key —
+        // otherwise a later file can silently wipe an earlier file's turns
+        // via graph::delete_session_turns() while the state cache still
+        // tracks them under separate, mismatched keys.
+        let root = scratch_dir("hermes-id-collision");
+        let workspace = root.join("myproj");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+
+        let path_a = write_hermes_fixture(&root, "dup_session", workspace.to_str().unwrap());
+        let path_b = root.join("other_filename.json");
+        std::fs::rename(&path_a, &path_b).expect("rename to distinct filename");
+        let path_a = write_hermes_fixture(&root, "dup_session", workspace.to_str().unwrap());
+
+        assert_ne!(
+            path_a.file_stem().and_then(|s| s.to_str()),
+            path_b.file_stem().and_then(|s| s.to_str()),
+            "fixtures must have distinct filenames to exercise the collision"
+        );
+
+        for path in [&path_a, &path_b] {
+            let content = std::fs::read_to_string(path).expect("read fixture");
+            let doc: serde_json::Value = serde_json::from_str(&content).expect("parse json");
+            let dedupe_key = resolve_hermes_session_id(&doc, path);
+            let graph_identity = parse_hermes_session(path).expect("parse").session_id;
+
+            assert_eq!(
+                dedupe_key, graph_identity,
+                "state key must match the graph MERGE identity for {path:?}"
+            );
+            assert_eq!(dedupe_key, "dup_session");
+        }
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -136,6 +136,27 @@ fn namespace_from_config_chain(path: &Path) -> Option<String> {
     None
 }
 
+/// Derive a namespace from a real filesystem path: honour the nearest
+/// `.c0/config.toml` in the ancestry, map `$HOME` to `global`, else use the
+/// leaf folder name. Shared by the Claude Code and Hermes ingest paths so both
+/// harnesses resolve namespaces identically.
+fn namespace_for_path(path: &Path) -> String {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/home"));
+
+    if let Some(ns) = namespace_from_config_chain(path) {
+        return ns;
+    }
+
+    if path == home {
+        return "global".to_string();
+    }
+
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("global")
+        .to_string()
+}
+
 fn derive_namespace(dir_name: &str) -> String {
     let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/home"));
 
@@ -151,18 +172,7 @@ fn derive_namespace(dir_name: &str) -> String {
             .to_string();
     };
 
-    if let Some(ns) = namespace_from_config_chain(&path) {
-        return ns;
-    }
-
-    if path == home {
-        return "global".to_string();
-    }
-
-    path.file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("global")
-        .to_string()
+    namespace_for_path(&path)
 }
 
 fn file_mtime_ms(path: &PathBuf) -> Option<u64> {
@@ -1006,6 +1016,283 @@ fn parse_jsonl_file(
     Ok(parsed)
 }
 
+// ---------------------------------------------------------------------------
+// Hermes agent session adapter
+//
+// Hermes (the harness behind Foreman/Fig/Rosie/Griot) persists each session as
+// a single JSON document under `~/.hermes/webui/sessions/<id>.json` with a rich
+// `messages` array plus a sibling `tool_calls` array. This adapter maps that
+// shape into c0's internal `ParsedSession`/`ParsedTurn` model so the existing
+// extract/enrich pipeline can ingest it unchanged. Claude Code ingestion is
+// untouched — this is a second, opt-in source (`c0 sessions import --from hermes`).
+// ---------------------------------------------------------------------------
+
+/// Default directory holding Hermes webui session stores.
+fn get_hermes_sessions_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".hermes/webui/sessions")
+}
+
+/// Convert a Hermes timestamp (epoch seconds as float, or RFC3339 string) into
+/// an RFC3339 string, matching the timestamp shape c0's Turn model expects.
+fn hermes_timestamp(v: Option<&serde_json::Value>) -> String {
+    let Some(v) = v else {
+        return String::new();
+    };
+    if let Some(s) = v.as_str() {
+        return s.to_string();
+    }
+    if let Some(secs) = v.as_f64() {
+        let nanos = ((secs.fract()) * 1_000_000_000.0).round() as u32;
+        if let Some(dt) = chrono::DateTime::<chrono::Utc>::from_timestamp(secs.trunc() as i64, nanos)
+        {
+            return dt.to_rfc3339();
+        }
+    }
+    String::new()
+}
+
+/// Pull the plain-text body out of a Hermes message `content` field, which is
+/// usually a string but may be an array of `{type:"text",text}` blocks.
+fn hermes_content_text(content: Option<&serde_json::Value>) -> String {
+    match content {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(serde_json::Value::Array(blocks)) => {
+            let mut out = String::new();
+            for block in blocks {
+                if block.get("type").and_then(|t| t.as_str()) == Some("text")
+                    && let Some(t) = block.get("text").and_then(|t| t.as_str())
+                {
+                    if !out.is_empty() {
+                        out.push('\n');
+                    }
+                    out.push_str(t);
+                }
+            }
+            out
+        }
+        _ => String::new(),
+    }
+}
+
+/// Build a `ParsedToolCall` from one entry of a Hermes assistant message's
+/// `tool_calls` array (OpenAI-style `{id, function:{name, arguments}}`).
+fn hermes_tool_call(tc: &serde_json::Value) -> Option<ParsedToolCall> {
+    let id = ext_string(tc, "id")
+        .or_else(|| ext_string(tc, "call_id"))
+        .unwrap_or_default();
+    if id.is_empty() {
+        return None;
+    }
+    let func = tc.get("function");
+    let name = func
+        .and_then(|f| ext_string(f, "name"))
+        .or_else(|| ext_string(tc, "name"))
+        .unwrap_or_default();
+
+    // `arguments` is a JSON string in the OpenAI convention; parse it so file
+    // touches / bash detection see structured input, and store canonical JSON.
+    let args_raw = func
+        .and_then(|f| f.get("arguments"))
+        .or_else(|| tc.get("arguments"));
+    let input: serde_json::Value = match args_raw {
+        Some(serde_json::Value::String(s)) => {
+            serde_json::from_str(s).unwrap_or(serde_json::Value::Null)
+        }
+        Some(other) => other.clone(),
+        None => serde_json::Value::Null,
+    };
+    let input_json = serde_json::to_string(&input).unwrap_or_default();
+    let file_touches = touches_for_hermes_tool(&name, &input);
+    let bash = bash_call_for_hermes_tool(&name, &input);
+
+    Some(ParsedToolCall {
+        tool_call_id: id,
+        name,
+        input_json,
+        file_touches,
+        bash,
+    })
+}
+
+/// Map a Hermes tool name + input to file touches. Hermes tool names differ
+/// from Claude Code's (`read_file`/`write_file`/`patch`/`search_files`), so we
+/// translate before delegating to the shared Claude-Code path.
+fn touches_for_hermes_tool(name: &str, input: &serde_json::Value) -> Vec<FileTouch> {
+    let action = match name {
+        "read_file" => "read",
+        "write_file" => "write",
+        "patch" => "edit",
+        "search_files" => "grep",
+        _ => return Vec::new(),
+    };
+    if let Some(p) = input.get("path").and_then(|v| v.as_str())
+        && !p.is_empty()
+    {
+        return vec![FileTouch {
+            path: p.to_string(),
+            action: action.to_string(),
+        }];
+    }
+    Vec::new()
+}
+
+/// Map a Hermes `terminal` tool call to a `BashCall`.
+fn bash_call_for_hermes_tool(name: &str, input: &serde_json::Value) -> Option<BashCall> {
+    if name != "terminal" {
+        return None;
+    }
+    let cmd = input
+        .get("command")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if cmd.is_empty() {
+        return None;
+    }
+    Some(BashCall {
+        cmd,
+        description: None,
+    })
+}
+
+/// Parse a Hermes webui session `.json` document into c0's `ParsedSession`.
+fn parse_hermes_session(path: &Path) -> Result<ParsedSession> {
+    let content = std::fs::read_to_string(path)?;
+    let doc: serde_json::Value = serde_json::from_str(&content)?;
+
+    let session_id = ext_string(&doc, "session_id")
+        .or_else(|| {
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .map(std::string::ToString::to_string)
+        })
+        .unwrap_or_default();
+
+    let workspace = ext_string(&doc, "workspace")
+        .or_else(|| ext_string(&doc, "created_workspace"))
+        .unwrap_or_default();
+    let namespace = if workspace.is_empty() {
+        "global".to_string()
+    } else {
+        namespace_for_path(Path::new(&workspace))
+    };
+
+    let created_at = hermes_timestamp(doc.get("created_at"));
+    let ended_at = {
+        let t = hermes_timestamp(doc.get("updated_at"));
+        if t.is_empty() { None } else { Some(t) }
+    };
+
+    let doc_model = ext_string(&doc, "model");
+
+    let mut parsed = ParsedSession {
+        session_id: session_id.clone(),
+        namespace,
+        cwd: workspace.clone(),
+        git_branch: ext_string(&doc, "worktree_branch"),
+        is_sidechain_overall: false,
+        summary: ext_string(&doc, "title"),
+        slug: ext_string(&doc, "title"),
+        created_at,
+        ended_at,
+        ..ParsedSession::default()
+    };
+
+    let empty = Vec::new();
+    let messages = doc
+        .get("messages")
+        .and_then(|m| m.as_array())
+        .unwrap_or(&empty);
+
+    let mut first_user_prompt_set = false;
+
+    for (idx, msg) in messages.iter().enumerate() {
+        let role = ext_string(msg, "role").unwrap_or_default();
+        if role.is_empty() {
+            continue;
+        }
+
+        let text = hermes_content_text(msg.get("content"));
+        let timestamp = hermes_timestamp(msg.get("timestamp"));
+        // Hermes messages carry no stable per-message id; synthesise a
+        // deterministic one so reply chains and re-imports stay stable.
+        let turn_id = format!("{session_id}#m{idx}");
+        let parent_turn_id = if idx == 0 {
+            None
+        } else {
+            Some(format!("{session_id}#m{}", idx - 1))
+        };
+
+        let mut turn = ParsedTurn {
+            turn_id: turn_id.clone(),
+            role: role.clone(),
+            text: text.clone(),
+            model: if role == "assistant" {
+                doc_model.clone()
+            } else {
+                None
+            },
+            timestamp,
+            parent_turn_id,
+            is_sidechain: false,
+            git_branch: parsed.git_branch.clone(),
+            cwd: if workspace.is_empty() {
+                None
+            } else {
+                Some(workspace.clone())
+            },
+            text_chars: text.len() as i64,
+            ..ParsedTurn::default()
+        };
+
+        // Reasoning → reflection. Hermes stores it as `reasoning_content`
+        // (preferred) or `reasoning`, both plain strings.
+        let reasoning = ext_string(msg, "reasoning_content").or_else(|| ext_string(msg, "reasoning"));
+        if let Some(r) = reasoning {
+            turn.thinking_chars += r.len() as i64;
+            turn.reflections.push(ParsedReflection {
+                reflection_id: format!("{turn_id}#r0"),
+                text: r,
+                signature: None,
+            });
+        }
+
+        // Assistant tool calls live in a per-message `tool_calls` array.
+        if let Some(tcs) = msg.get("tool_calls").and_then(|t| t.as_array()) {
+            for tc in tcs {
+                if let Some(parsed_tc) = hermes_tool_call(tc) {
+                    turn.tool_use_count += 1;
+                    if !turn.tool_use_names.iter().any(|n| n == &parsed_tc.name) {
+                        turn.tool_use_names.push(parsed_tc.name.clone());
+                    }
+                    turn.toolcalls.push(parsed_tc);
+                }
+            }
+        }
+
+        if !first_user_prompt_set && role == "user" && !turn.text.is_empty() {
+            let snippet = if turn.text.len() > 4096 {
+                safe_truncate(&turn.text, 4096)
+            } else {
+                &turn.text
+            };
+            parsed.first_prompt = snippet.to_string();
+            first_user_prompt_set = true;
+        }
+
+        parsed.turns.push(turn);
+    }
+
+    if parsed.first_prompt.is_empty() {
+        parsed.first_prompt = "No prompt".to_string();
+    }
+
+    Ok(parsed)
+}
+
 async fn embed_text_opt(
     client: Option<&embeddings::OllamaClient>,
     text: &str,
@@ -1303,6 +1590,112 @@ pub async fn extract_all(force: bool, skip_sidechains: bool) -> Result<ExtractSt
     println!();
     println!(
         "Extracted {} session(s) ({} skipped, {} errors)",
+        stats.sessions_extracted, stats.sessions_skipped, stats.errors
+    );
+    println!(
+        "Emitted {} turn(s), {} reflection(s), {} toolcall(s), {} embedding call(s)",
+        stats.turns_emitted, stats.reflections_emitted, stats.toolcalls_emitted, stats.embed_calls
+    );
+    Ok(stats)
+}
+
+/// Import all Hermes agent sessions under `~/.hermes/webui/sessions/*.json`
+/// into the graph, reusing the same turn/reflection/toolcall pipeline as the
+/// Claude Code path. Incremental via the turns-state store, keyed under a
+/// synthetic `hermes` dir name so it never collides with Claude project dirs.
+pub async fn import_hermes_sessions(force: bool) -> Result<ExtractStats> {
+    let sessions_dir = get_hermes_sessions_dir();
+    if !sessions_dir.exists() {
+        println!("No Hermes sessions directory found at {}", sessions_dir.display());
+        return Ok(ExtractStats::default());
+    }
+
+    let semantic_config = config::SemanticConfig::load();
+    let ollama = embeddings::OllamaClient::from_config(&semantic_config);
+    let graph_conn = graph::connect().await?;
+    graph::ensure_turn_indexes(&graph_conn).await?;
+
+    let mut state = load_turns_state();
+    let mut stats = ExtractStats::default();
+
+    // Session stores are top-level `*.json` files; skip the `_index.json`
+    // sidecar and the `_turn_journal` / `_run_journal` subdirectories.
+    let json_files: Vec<_> = std::fs::read_dir(&sessions_dir)?
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .map(|n| !n.starts_with('_'))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    println!(
+        "Scanning {} Hermes session store(s) under {}",
+        json_files.len(),
+        sessions_dir.display()
+    );
+
+    let dir_state = state.dirs.entry("hermes".to_string()).or_default();
+
+    use std::io::Write;
+    for f in &json_files {
+        let path = f.path();
+        let session_id = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        if session_id.is_empty() {
+            continue;
+        }
+
+        let current_mtime = file_mtime_ms(&path);
+        let stored_mtime = dir_state.sessions.get(&session_id).copied();
+
+        if !force && stored_mtime == current_mtime && current_mtime.is_some() {
+            stats.sessions_skipped += 1;
+            continue;
+        }
+
+        match parse_hermes_session(&path) {
+            Ok(parsed) => {
+                let namespace = parsed.namespace.clone();
+                let n_turns = parsed.turns.len();
+                let n_refl: usize = parsed.turns.iter().map(|t| t.reflections.len()).sum();
+                let n_tc: usize = parsed.turns.iter().map(|t| t.toolcalls.len()).sum();
+                print!(
+                    "  [{namespace}] {session_id} → {n_turns} turn(s), {n_refl} refl, {n_tc} tc ... "
+                );
+                std::io::stdout().flush().ok();
+
+                match write_parsed_session(&graph_conn, parsed, ollama.as_ref(), &mut stats).await {
+                    Ok(()) => {
+                        stats.sessions_extracted += 1;
+                        if let Some(m) = current_mtime {
+                            dir_state.sessions.insert(session_id, m);
+                        }
+                        println!("✓");
+                    }
+                    Err(e) => {
+                        stats.errors += 1;
+                        println!("✗ {e}");
+                    }
+                }
+            }
+            Err(e) => {
+                stats.errors += 1;
+                eprintln!("  parse error for {session_id}: {e}");
+            }
+        }
+    }
+
+    save_turns_state(&state)?;
+
+    println!();
+    println!(
+        "Imported {} Hermes session(s) ({} skipped, {} errors)",
         stats.sessions_extracted, stats.sessions_skipped, stats.errors
     );
     println!(
@@ -2335,6 +2728,136 @@ mod enrichment_tests {
         let mut sorted = picked.clone();
         sorted.sort_unstable();
         assert_eq!(picked, sorted);
+    }
+
+    fn write_hermes_fixture(dir: &Path, session_id: &str, workspace: &str) -> PathBuf {
+        // A minimal Hermes webui session store (.json): rich `messages` +
+        // sibling `tool_calls`, matching the live on-disk shape.
+        let doc = serde_json::json!({
+            "session_id": session_id,
+            "title": "Fixture session",
+            "workspace": workspace,
+            "model": "claude-opus-4-8",
+            "model_provider": "anthropic",
+            "created_at": 1_787_082_467.6_f64,
+            "updated_at": 1_787_083_725.7_f64,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "hello there, please help",
+                    "timestamp": 1_787_082_467.6_f64
+                },
+                {
+                    "role": "assistant",
+                    "content": "On it — let me look.",
+                    "timestamp": 1_787_082_470.0_f64,
+                    "reasoning_content": "The user wants help; I'll run a command.",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_abc123",
+                            "call_id": "toolu_abc123",
+                            "type": "function",
+                            "function": {
+                                "name": "terminal",
+                                "arguments": "{\"command\": \"ls -la /tmp\"}"
+                            }
+                        },
+                        {
+                            "id": "toolu_def456",
+                            "call_id": "toolu_def456",
+                            "type": "function",
+                            "function": {
+                                "name": "read_file",
+                                "arguments": "{\"path\": \"/etc/hosts\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "total 0\ndrwxr-xr-x ...",
+                    "timestamp": 1_787_082_471.0_f64,
+                    "tool_call_id": "toolu_abc123",
+                    "tool_name": "terminal"
+                }
+            ],
+            "tool_calls": []
+        });
+        let path = dir.join(format!("{session_id}.json"));
+        std::fs::write(&path, serde_json::to_string(&doc).expect("serialize")).expect("write");
+        path
+    }
+
+    #[test]
+    fn parses_hermes_session_into_turn_model() {
+        let root = scratch_dir("hermes-basic");
+        let workspace = root.join("myproj");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+        let path = write_hermes_fixture(&root, "sess_hermes_1", workspace.to_str().unwrap());
+
+        let parsed = parse_hermes_session(&path).expect("parse");
+
+        assert_eq!(parsed.session_id, "sess_hermes_1");
+        // Namespace derives from the Hermes workspace leaf folder.
+        assert_eq!(parsed.namespace, "myproj");
+        assert_eq!(parsed.cwd, workspace.to_str().unwrap());
+        assert_eq!(parsed.turns.len(), 3);
+
+        // First user prompt is captured.
+        assert_eq!(parsed.first_prompt, "hello there, please help");
+        assert_eq!(parsed.turns[0].role, "user");
+        assert_eq!(parsed.turns[0].text, "hello there, please help");
+        assert!(!parsed.turns[0].timestamp.is_empty());
+
+        // Assistant turn: model, reasoning->reflection, two tool calls.
+        let asst = &parsed.turns[1];
+        assert_eq!(asst.role, "assistant");
+        assert_eq!(asst.model.as_deref(), Some("claude-opus-4-8"));
+        assert_eq!(asst.reflections.len(), 1);
+        assert_eq!(asst.reflections[0].text, "The user wants help; I'll run a command.");
+        assert_eq!(asst.tool_use_count, 2);
+        assert_eq!(asst.toolcalls.len(), 2);
+        assert_eq!(asst.toolcalls[0].name, "terminal");
+        assert_eq!(
+            asst.toolcalls[0].bash.as_ref().map(|b| b.cmd.as_str()),
+            Some("ls -la /tmp")
+        );
+        // read_file registers a file touch.
+        assert_eq!(asst.toolcalls[1].name, "read_file");
+        assert_eq!(asst.toolcalls[1].file_touches.len(), 1);
+        assert_eq!(asst.toolcalls[1].file_touches[0].path, "/etc/hosts");
+        assert_eq!(asst.toolcalls[1].file_touches[0].action, "read");
+
+        // Tool result turn preserved as its own turn.
+        assert_eq!(parsed.turns[2].role, "tool");
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn hermes_namespace_honours_c0_config_chain() {
+        let root = scratch_dir("hermes-ns");
+        let project = root.join("reserve-padel");
+        let workspace = project.join("repo").join("main");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+        std::fs::create_dir_all(project.join(".c0")).expect("create .c0");
+        std::fs::write(
+            project.join(".c0/config.toml"),
+            "namespace = \"reserve-padel\"\n",
+        )
+        .expect("write config");
+
+        let path = write_hermes_fixture(&root, "sess_hermes_2", workspace.to_str().unwrap());
+        let parsed = parse_hermes_session(&path).expect("parse");
+        assert_eq!(parsed.namespace, "reserve-padel");
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn namespace_for_path_maps_home_to_global() {
+        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/home"));
+        assert_eq!(namespace_for_path(&home), "global");
     }
 
     #[test]


### PR DESCRIPTION
## What Changed

- Added a new `c0 sessions import --from hermes [--force]` CLI subcommand (`src/main.rs`) that reads Hermes webui session stores (`~/.hermes/webui/sessions/*.json`) and ingests them into the graph through the existing turn/reflection/toolcall pipeline.
- Implemented the Hermes adapter in `src/sessions.rs`: parses each session's `messages` array (roles, text/reasoning content, per-message `tool_calls`) into c0's `ParsedSession`/`ParsedTurn` model, maps Hermes tool names (`read_file`, `write_file`, `patch`, `search_files`, `terminal`) to file touches and bash calls, derives namespace from the session's workspace path, and performs incremental import via mtime-keyed dedupe state (keyed by filename stem, read+parsed once per file, stored under a synthetic `hermes` state directory so it doesn't collide with Claude Code project dirs).
- Extracted a shared `namespace_for_path` helper used by both the Claude Code and Hermes ingestion paths for consistent namespace resolution.
- Updated `README.md` to document the new `c0 sessions import --from hermes` command as a second source-adapter example.

## Risk Assessment

✅ Low: The round-3 fix now derives the Hermes session identity from the filename stem consistently everywhere it matters — parse_hermes_session_doc's session_id, hermes_dedupe_decision's skip-check lookup, and the post-write state store all call the same hermes_file_session_id(path) — so the skip-key/store-key mismatch and the internal-session_id collision from earlier rounds are both closed, and unchanged files remain stat()-only while changed files are read/parsed exactly once. The new tests (parses_hermes_session_into_turn_model, hermes_graph_identity_ignores_colliding_internal_session_id, hermes_dedupe_decision_skip_key_matches_store_key, hermes_namespace_honours_c0_config_chain) exercise the real parse/dedupe functions and assert on structured output, not source text, satisfying the test-quality bar. The feature is additive and opt-in (new `sessions import --from hermes` subcommand), doesn't touch the existing Claude Code ingestion path, and is well-bounded in scope.

## Testing

Targeted unit tests for the Hermes session-ingestor identity fix (all 3 rounds' concerns) pass cleanly; end-to-end import_hermes_sessions() can't be exercised because this sandbox has no running Neo4j/docker, so evidence is at the unit level (actual identity/dedupe-decision functions, not source-text matching), which is the most complete verification feasible here.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"61d637c5a469fb993d1f4b56e63ef2748fef189c","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- ⚠️ `src/sessions.rs:1166` - parse_hermes_session() derives the graph identity (parsed.session_id, used as the MERGE key for Session/Turn nodes and passed to graph::delete_session_turns) from the JSON document&#39;s own session_id field first, falling back to the filename only if that field is absent. Meanwhile import_hermes_sessions()&#39;s incremental skip/dedupe state is keyed purely by the file&#39;s stem name. If two Hermes session files ever carry the same internal session_id value, importing the second file calls delete_session_turns() on the shared id and silently wipes the first file&#39;s turns from the graph; since the first file&#39;s mtime is unchanged, it keeps being skipped on future runs, so the data loss is never surfaced. The sibling Claude Code path always uses the file stem as the session id and never trusts an in-document id. Preferring the filename first would remove this divergence risk without changing behavior for the well-formed case.

🔧 Fix: fix(sessions): align hermes dedupe state key with graph identity
1 warning still open:

- ⚠️ `src/sessions.rs:1655` - The fix round changed the per-file loop in import_hermes_sessions() to read and JSON-parse every Hermes session file up front just to compute the dedupe key (resolve_hermes_session_id), including files that end up skipped because their mtime hasn&#39;t changed (line 1679). Previously this loop derived the key from the filename alone with zero I/O, so unchanged sessions cost only a stat() call; now every run does a full read+parse of every file in the sessions directory regardless of whether it changed. Additionally, for files that do proceed past the skip check, parse_hermes_session(&amp;path) at line 1684 independently re-reads and re-parses the same file from disk (it takes a Path, not the already-parsed `doc`), so processed files are read and parsed twice per run. The second cost is purely mechanical and fixable without behavior change: change parse_hermes_session to accept the already-parsed serde_json::Value (plus path, for the filename-fallback branch) instead of re-reading from disk, eliminating the redundant I/O/parse for every non-skipped file.

🔧 Fix: fix(sessions): avoid double read/parse in hermes import
1 error still open:

- 🚨 `src/sessions.rs:1669` - The round-2 fix (moving read+parse after the mtime skip check) made the skip-check lookup and the post-write store use two different keys, reopening the exact data-loss bug round 1 was meant to close. Line 1669 looks up dir_state.sessions[filename_key] (file stem, zero I/O) to decide whether to skip; the success branch at line 1709 stores under dir_state.sessions[session_id] (resolved from the parsed JSON body, which per resolve_hermes_session_id/round-1&#39;s own fix can legitimately differ from the filename stem). Whenever a file&#39;s internal session_id differs from its filename stem, the entry written after processing is never the entry the next run&#39;s skip check reads, so (1) the skip optimization never engages for that file — every run re-reads/re-parses it, silently defeating the round-2 perf fix; and (2) for two files that share the same internal session_id but have different filenames (the exact collision scenario round 1&#39;s own regression test targets), both files are reprocessed on every run since neither&#39;s filename-keyed lookup ever matches the session_id-keyed entry left by the other. Each reprocessing calls write_parsed_session -&gt; graph::delete_session_turns(session_id) (src/sessions.rs:1356) before rewriting, so on every import run the two files alternately wipe and rewrite each other&#39;s turns under the shared session_id — a continuous, non-deterministic recurrence of the same collision data-loss round 1 flagged, now happening every run instead of once. The added test hermes_dedupe_key_matches_graph_identity_on_id_collision only asserts resolve_hermes_session_id/parse_hermes_session agree in isolation; it never calls import_hermes_sessions, so it does not exercise this loop and does not catch the mismatch. Fix by using one consistent key for both the lookup (line 1669) and the store (line 1709) in this loop.

🔧 Fix: fix(sessions): use filename stem as sole hermes session identity
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo test --bin c0 --features sessions sessions::enrichment_tests::hermes -- --nocapture (3 tests: hermes_dedupe_decision_skip_key_matches_store_key, hermes_graph_identity_ignores_colliding_internal_session_id, hermes_namespace_honours_c0_config_chain) — all pass`
- `cargo test --bin c0 --features sessions sessions::enrichment_tests -- --nocapture (full module, 15 tests including parses_hermes_session_into_turn_model) — all pass`
- `Manual diff review of e71cb60..27dffc1 confirming hermes_dedupe_decision_skip_key_matches_store_key exercises exactly the round-3 bug: old code's skip-check key (filename stem) and post-write store key (doc-derived resolve_hermes_session_id) could diverge; new code uses hermes_file_session_id(path) for both, and the test asserts lookup key == store key plus correct skip behavior`
- `git status --porcelain confirming the worktree is clean after testing (no transient artifacts left)`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
