### PR TITLE
feat(sessions): route extracted concepts to per-topic namespaces

### DIFF
--- a/src/claude.rs
+++ b/src/claude.rs
@@ -1209,15 +1209,16 @@ const SESSION_CONCEPT_SCHEMA: &str = r#"{"type":"object","properties":{"concepts
 
 /// Topic-aware variant of the session concept prompt. Used only when per-topic
 /// namespace routing is enabled: each concept also carries a `topic` label the
-/// router snaps onto the known-namespace vocabulary. `{known}` is replaced with
-/// the current controlled vocabulary so the model reuses existing namespaces.
+/// router snaps onto the allowed-namespace set. `{known}` is replaced with the
+/// session's own namespace ancestry (self + parents + global) plus the
+/// configured allow-list — the ONLY buckets a concept may be filed under.
 #[cfg(feature = "sessions")]
 const SESSION_CONCEPT_TOPIC_PROMPT: &str = r#"You are a knowledge curator. Extract distinct technology concepts, libraries, frameworks, patterns, methodologies, or domain ideas discussed in this Claude Code session.
 
 For each concept return:
 - name: lowercase kebab-case identifier (e.g. "rust-async", "neo4j-vector-index", "systemd-timer")
 - description: one-sentence summary of what was discussed about it (max 200 chars)
-- topic: the single best topic/project this concept belongs to, as a lowercase kebab-case label. PREFER an existing topic from this list when one fits: {known}. Only invent a new topic label when none of the existing ones apply.
+- topic: which of these buckets this concept belongs in, chosen from this list: {known}. Pick the single best-fitting bucket. If none of them clearly fit, use the first (the session's own namespace). Do NOT invent bucket names outside this list.
 
 Rules:
 - Extract up to {max} distinct concepts, ranked by relevance

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -1174,6 +1174,11 @@ pub struct ConceptExtractionResult {
 pub struct ExtractedConcept {
     pub name: String,
     pub description: String,
+    /// Optional topic label proposed by the classifier. When per-topic
+    /// namespace routing is enabled it is snapped onto the known-namespace
+    /// vocabulary; otherwise it is ignored and the source namespace is used.
+    #[serde(default)]
+    pub topic: Option<String>,
 }
 
 #[cfg(feature = "sessions")]
@@ -1201,6 +1206,60 @@ Session text:
 
 #[cfg(feature = "sessions")]
 const SESSION_CONCEPT_SCHEMA: &str = r#"{"type":"object","properties":{"concepts":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"description":{"type":"string"}},"required":["name","description"],"additionalProperties":false}}},"required":["concepts"],"additionalProperties":false}"#;
+
+/// Topic-aware variant of the session concept prompt. Used only when per-topic
+/// namespace routing is enabled: each concept also carries a `topic` label the
+/// router snaps onto the known-namespace vocabulary. `{known}` is replaced with
+/// the current controlled vocabulary so the model reuses existing namespaces.
+#[cfg(feature = "sessions")]
+const SESSION_CONCEPT_TOPIC_PROMPT: &str = r#"You are a knowledge curator. Extract distinct technology concepts, libraries, frameworks, patterns, methodologies, or domain ideas discussed in this Claude Code session.
+
+For each concept return:
+- name: lowercase kebab-case identifier (e.g. "rust-async", "neo4j-vector-index", "systemd-timer")
+- description: one-sentence summary of what was discussed about it (max 200 chars)
+- topic: the single best topic/project this concept belongs to, as a lowercase kebab-case label. PREFER an existing topic from this list when one fits: {known}. Only invent a new topic label when none of the existing ones apply.
+
+Rules:
+- Extract up to {max} distinct concepts, ranked by relevance
+- Names must be lowercase kebab-case, alphanumeric + hyphens only
+- Skip generic terms: database, api, code, app, file, function, variable, system, hook, type, stuff, things, service
+- Skip pronouns, articles, and one-off local names (file paths, variable names)
+- Skip people's names
+- Each concept should be something you'd actually want to look up later
+
+Return ONLY valid JSON in this exact format (no prose, no markdown):
+{"concepts": [{"name": "...", "description": "...", "topic": "..."}]}
+
+If no extractable concepts, return: {"concepts": []}
+
+Session text:
+{text}"#;
+
+#[cfg(feature = "sessions")]
+const SESSION_CONCEPT_TOPIC_SCHEMA: &str = r#"{"type":"object","properties":{"concepts":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"description":{"type":"string"},"topic":{"type":"string"}},"required":["name","description","topic"],"additionalProperties":false}}},"required":["concepts"],"additionalProperties":false}"#;
+
+/// Normalize a raw topic label into a namespace-safe token: lowercase,
+/// kebab-case, alphanumeric + hyphens only. Returns `None` for empty, missing,
+/// or fully-invalid labels so callers fall back to the source namespace.
+pub fn sanitize_topic_label(raw: Option<&str>) -> Option<String> {
+    let raw = raw?;
+    let mut token = String::with_capacity(raw.len());
+    let mut prev_hyphen = false;
+    for ch in raw.trim().to_lowercase().chars() {
+        if ch.is_ascii_alphanumeric() {
+            token.push(ch);
+            prev_hyphen = false;
+        } else if (ch == '-' || ch == '_' || ch == ' ' || ch == '/') && !prev_hyphen {
+            token.push('-');
+            prev_hyphen = true;
+        }
+    }
+    let trimmed = token.trim_matches('-').to_string();
+    if trimmed.len() < 2 || trimmed.len() > 60 {
+        return None;
+    }
+    Some(trimmed)
+}
 
 const CONCEPT_EXTRACTION_PROMPT: &str = r#"Extract 1-3 specific technology concepts from this prompt that would benefit from knowledge lookup.
 
@@ -1280,6 +1339,37 @@ impl LlmClient {
 
         parse_session_concepts(&response.result, max_concepts)
     }
+
+    /// Topic-aware extraction: each concept also carries a `topic` label the
+    /// caller snaps onto the known-namespace vocabulary. `known` is the current
+    /// controlled vocabulary offered to the model to encourage reuse.
+    #[cfg(feature = "sessions")]
+    pub async fn extract_session_concepts_with_topics(
+        &self,
+        text: &str,
+        max_concepts: usize,
+        known: &[String],
+    ) -> Result<Vec<ExtractedConcept>> {
+        let known_list = if known.is_empty() {
+            "(none yet — propose concise topic labels)".to_string()
+        } else {
+            known.join(", ")
+        };
+        let prompt = SESSION_CONCEPT_TOPIC_PROMPT
+            .replace("{max}", &max_concepts.to_string())
+            .replace("{known}", &known_list)
+            .replace("{text}", text);
+
+        let response = self
+            .generate(&prompt, Some(SESSION_CONCEPT_TOPIC_SCHEMA))
+            .await?;
+
+        if let Some(cost) = response.total_cost_usd {
+            log_usage("session-enrichment", &self.model, cost);
+        }
+
+        parse_session_concepts(&response.result, max_concepts)
+    }
 }
 
 #[cfg(feature = "sessions")]
@@ -1333,7 +1423,11 @@ fn parse_session_concepts(raw: &str, max: usize) -> Result<Vec<ExtractedConcept>
             } else {
                 description
             };
-            Some(ExtractedConcept { name, description })
+            Some(ExtractedConcept {
+                name,
+                description,
+                topic: sanitize_topic_label(c.topic.as_deref()),
+            })
         })
         .take(max)
         .collect();
@@ -1422,5 +1516,66 @@ mod tests {
             err.to_string().contains("OPENROUTER_API_KEY not set"),
             "unexpected error message: {err}"
         );
+    }
+
+    #[test]
+    fn sanitize_topic_label_normalizes_to_kebab() {
+        assert_eq!(
+            sanitize_topic_label(Some("  ISSA Project ")),
+            Some("issa-project".to_string())
+        );
+        assert_eq!(
+            sanitize_topic_label(Some("home_school")),
+            Some("home-school".to_string())
+        );
+        assert_eq!(
+            sanitize_topic_label(Some("c0/graph")),
+            Some("c0-graph".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_topic_label_collapses_and_trims_separators() {
+        assert_eq!(
+            sanitize_topic_label(Some("--foo   bar--")),
+            Some("foo-bar".to_string())
+        );
+        assert_eq!(
+            sanitize_topic_label(Some("a !!! b")),
+            Some("a-b".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_topic_label_rejects_empty_or_invalid() {
+        assert_eq!(sanitize_topic_label(None), None);
+        assert_eq!(sanitize_topic_label(Some("")), None);
+        assert_eq!(sanitize_topic_label(Some("   ")), None);
+        assert_eq!(sanitize_topic_label(Some("!!!")), None);
+        // Single alphanumeric char is below the 2-char floor.
+        assert_eq!(sanitize_topic_label(Some("x")), None);
+    }
+
+    #[cfg(feature = "sessions")]
+    #[test]
+    fn parse_session_concepts_reads_topic_field() {
+        let raw = r#"{"concepts":[
+            {"name":"neo4j-vector-index","description":"Vector search in Neo4j","topic":"C0"},
+            {"name":"issa-enrollment","description":"ISSA student enrollment flow","topic":"issa"}
+        ]}"#;
+        let out = parse_session_concepts(raw, 5).unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].topic.as_deref(), Some("c0"));
+        assert_eq!(out[1].topic.as_deref(), Some("issa"));
+    }
+
+    #[cfg(feature = "sessions")]
+    #[test]
+    fn parse_session_concepts_tolerates_missing_topic() {
+        // Legacy schema (no topic) must still parse; topic defaults to None.
+        let raw = r#"{"concepts":[{"name":"rust-async","description":"async runtime"}]}"#;
+        let out = parse_session_concepts(raw, 5).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].topic, None);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,21 @@ pub struct ExtractionSettings {
     pub queue_unknown: bool,
     #[serde(default = "default_concept_extraction_timeout")]
     pub timeout_secs: u64,
+    /// Route each extracted concept to a topic-derived namespace instead of the
+    /// single folder-derived source namespace. Opt-in; default preserves the
+    /// legacy one-namespace-per-source behavior.
+    #[serde(default = "default_per_topic_namespace")]
+    pub per_topic_namespace: bool,
+    /// Optional controlled vocabulary of topic namespaces. Merged with the
+    /// namespaces already present in the graph to form the known set the router
+    /// snaps classifier labels onto.
+    #[serde(default)]
+    pub known_namespaces: Vec<String>,
+    /// When per-topic routing is on and a classifier label matches no known
+    /// namespace, allow minting it as a new namespace. Default false keeps the
+    /// concept in the source namespace to avoid namespace sprawl.
+    #[serde(default = "default_allow_new_namespaces")]
+    pub allow_new_namespaces: bool,
 }
 
 impl Default for ExtractionSettings {
@@ -51,6 +66,9 @@ impl Default for ExtractionSettings {
             max_concepts: default_concept_extraction_max_concepts(),
             queue_unknown: default_concept_extraction_queue_unknown(),
             timeout_secs: default_concept_extraction_timeout(),
+            per_topic_namespace: default_per_topic_namespace(),
+            known_namespaces: Vec::new(),
+            allow_new_namespaces: default_allow_new_namespaces(),
         }
     }
 }
@@ -73,6 +91,14 @@ fn default_concept_extraction_queue_unknown() -> bool {
 
 fn default_concept_extraction_timeout() -> u64 {
     90
+}
+
+fn default_per_topic_namespace() -> bool {
+    false
+}
+
+fn default_allow_new_namespaces() -> bool {
+    false
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -373,6 +399,9 @@ pub struct ExtractionConfig {
     pub max_concepts: usize,
     pub queue_unknown: bool,
     pub timeout_secs: u64,
+    pub per_topic_namespace: bool,
+    pub known_namespaces: Vec<String>,
+    pub allow_new_namespaces: bool,
 }
 
 impl ExtractionConfig {
@@ -384,6 +413,9 @@ impl ExtractionConfig {
             max_concepts: global_config.extraction.max_concepts,
             queue_unknown: global_config.extraction.queue_unknown,
             timeout_secs: global_config.extraction.timeout_secs,
+            per_topic_namespace: global_config.extraction.per_topic_namespace,
+            known_namespaces: global_config.extraction.known_namespaces,
+            allow_new_namespaces: global_config.extraction.allow_new_namespaces,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,21 +41,9 @@ pub struct ExtractionSettings {
     pub queue_unknown: bool,
     #[serde(default = "default_concept_extraction_timeout")]
     pub timeout_secs: u64,
-    /// Route each extracted concept to a topic-derived namespace instead of the
-    /// single folder-derived source namespace. Opt-in; default preserves the
-    /// legacy one-namespace-per-source behavior.
-    #[serde(default = "default_per_topic_namespace")]
-    pub per_topic_namespace: bool,
-    /// Optional controlled vocabulary of topic namespaces. Merged with the
-    /// namespaces already present in the graph to form the known set the router
-    /// snaps classifier labels onto.
+    /// Per-topic namespace routing knobs, grouped under `[extraction.routing]`.
     #[serde(default)]
-    pub known_namespaces: Vec<String>,
-    /// When per-topic routing is on and a classifier label matches no known
-    /// namespace, allow minting it as a new namespace. Default false keeps the
-    /// concept in the source namespace to avoid namespace sprawl.
-    #[serde(default = "default_allow_new_namespaces")]
-    pub allow_new_namespaces: bool,
+    pub routing: RoutingSettings,
 }
 
 impl Default for ExtractionSettings {
@@ -66,9 +54,35 @@ impl Default for ExtractionSettings {
             max_concepts: default_concept_extraction_max_concepts(),
             queue_unknown: default_concept_extraction_queue_unknown(),
             timeout_secs: default_concept_extraction_timeout(),
-            per_topic_namespace: default_per_topic_namespace(),
+            routing: RoutingSettings::default(),
+        }
+    }
+}
+
+/// `[extraction.routing]`: route each extracted concept into a topic-derived
+/// namespace drawn from the session's OWN namespace ancestry (self + parent
+/// chain + `global`) plus the explicit `known_namespaces` allow-list. Scoping
+/// to ancestry makes cross-project namespace writes impossible by construction.
+#[derive(Debug, Deserialize, Clone)]
+pub struct RoutingSettings {
+    /// Turn per-topic routing on. Opt-in; default preserves the legacy
+    /// one-namespace-per-source behavior.
+    #[serde(default = "default_per_topic_namespace")]
+    pub enabled: bool,
+    /// Extra namespaces the router may write into beyond the session's own
+    /// ancestry — an explicit cross-cutting allow-list (e.g. a shared
+    /// `reference` bucket). A classifier label matching none of ancestry-or-
+    /// allow-list falls back to the source namespace; peer projects are never
+    /// reachable.
+    #[serde(default)]
+    pub known_namespaces: Vec<String>,
+}
+
+impl Default for RoutingSettings {
+    fn default() -> Self {
+        Self {
+            enabled: default_per_topic_namespace(),
             known_namespaces: Vec::new(),
-            allow_new_namespaces: default_allow_new_namespaces(),
         }
     }
 }
@@ -94,10 +108,6 @@ fn default_concept_extraction_timeout() -> u64 {
 }
 
 fn default_per_topic_namespace() -> bool {
-    false
-}
-
-fn default_allow_new_namespaces() -> bool {
     false
 }
 
@@ -399,9 +409,16 @@ pub struct ExtractionConfig {
     pub max_concepts: usize,
     pub queue_unknown: bool,
     pub timeout_secs: u64,
-    pub per_topic_namespace: bool,
+    pub routing: RoutingConfig,
+}
+
+/// Runtime view of `[extraction.routing]`. Kept as its own struct so the
+/// routing knobs travel together and `ExtractionConfig` stays under clippy's
+/// `struct_excessive_bools` limit.
+#[derive(Debug, Clone)]
+pub struct RoutingConfig {
+    pub enabled: bool,
     pub known_namespaces: Vec<String>,
-    pub allow_new_namespaces: bool,
 }
 
 impl ExtractionConfig {
@@ -413,9 +430,10 @@ impl ExtractionConfig {
             max_concepts: global_config.extraction.max_concepts,
             queue_unknown: global_config.extraction.queue_unknown,
             timeout_secs: global_config.extraction.timeout_secs,
-            per_topic_namespace: global_config.extraction.per_topic_namespace,
-            known_namespaces: global_config.extraction.known_namespaces,
-            allow_new_namespaces: global_config.extraction.allow_new_namespaces,
+            routing: RoutingConfig {
+                enabled: global_config.extraction.routing.enabled,
+                known_namespaces: global_config.extraction.routing.known_namespaces,
+            },
         }
     }
 }
@@ -479,6 +497,35 @@ impl NamespaceContext {
             project_type: None,
         }
     }
+}
+
+/// Resolve a namespace *name* to its own ancestry: `[self, ...parents, global]`.
+///
+/// Unlike [`detect_namespace`], which reads the current working directory, this
+/// starts from a namespace label (e.g. the namespace a session was ingested
+/// under) and looks its `.c0` config up on disk to walk the parent chain. It is
+/// the sole source of the controlled vocabulary for per-topic routing: a
+/// session may only write concepts into its own ancestry, never a peer project.
+///
+/// Falls back to `[namespace, "global"]` when the namespace has no resolvable
+/// `.c0/config.toml` (e.g. a bare graph-only namespace) so routing still has the
+/// session's own bucket plus the shared global bucket to snap onto.
+pub fn resolve_namespaces(namespace: &str) -> Vec<String> {
+    let mut namespaces = vec![namespace.to_string()];
+
+    let start_dir = std::env::current_dir().ok();
+    if let Some((c0_dir, config)) = find_namespace_dir(namespace, start_dir.as_deref()) {
+        let (_parent_dirs, parent_namespaces) =
+            resolve_parent_chain(config.parent_namespace.as_deref(), &c0_dir);
+        namespaces.extend(parent_namespaces);
+        if config.inherit_global && !namespaces.iter().any(|n| n == "global") {
+            namespaces.push("global".to_string());
+        }
+    } else if !namespaces.iter().any(|n| n == "global") {
+        namespaces.push("global".to_string());
+    }
+
+    namespaces
 }
 
 pub fn detect_namespace() -> NamespaceContext {

--- a/src/config.rs
+++ b/src/config.rs
@@ -507,13 +507,21 @@ impl NamespaceContext {
 /// the sole source of the controlled vocabulary for per-topic routing: a
 /// session may only write concepts into its own ancestry, never a peer project.
 ///
+/// `start_dir` seeds the upward `.c0` search and should be the directory that
+/// actually belongs to `namespace` (e.g. a session's recorded `cwd`), not
+/// necessarily the invoking process's own working directory — a batch job or
+/// `--session <id>` call may run from anywhere. Pass `None` to fall back to
+/// the current process's working directory.
+///
 /// Falls back to `[namespace, "global"]` when the namespace has no resolvable
 /// `.c0/config.toml` (e.g. a bare graph-only namespace) so routing still has the
 /// session's own bucket plus the shared global bucket to snap onto.
-pub fn resolve_namespaces(namespace: &str) -> Vec<String> {
+pub fn resolve_namespaces(namespace: &str, start_dir: Option<&Path>) -> Vec<String> {
     let mut namespaces = vec![namespace.to_string()];
 
-    let start_dir = std::env::current_dir().ok();
+    let start_dir = start_dir
+        .map(Path::to_path_buf)
+        .or_else(|| std::env::current_dir().ok());
     if let Some((c0_dir, config)) = find_namespace_dir(namespace, start_dir.as_deref()) {
         let (_parent_dirs, parent_namespaces) =
             resolve_parent_chain(config.parent_namespace.as_deref(), &c0_dir);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -265,26 +265,6 @@ pub async fn add_concept(
     Ok(())
 }
 
-/// Every distinct namespace currently present on a `Concept` node. Used to seed
-/// the controlled vocabulary for per-topic namespace routing so the classifier
-/// reuses existing namespaces instead of minting near-duplicates.
-pub async fn list_namespaces(graph: &Graph) -> Result<Vec<String>> {
-    let q = query(
-        "MATCH (c:Concept)
-         WHERE c.namespace IS NOT NULL AND c.namespace <> ''
-         RETURN DISTINCT c.namespace AS ns
-         ORDER BY ns",
-    );
-    let mut result = graph.execute(q).await?;
-    let mut namespaces = Vec::new();
-    while let Some(row) = result.next().await? {
-        if let Ok(ns) = row.get::<String>("ns") {
-            namespaces.push(ns);
-        }
-    }
-    Ok(namespaces)
-}
-
 pub async fn update_concept_embedding(
     graph: &Graph,
     name: &str,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -265,6 +265,26 @@ pub async fn add_concept(
     Ok(())
 }
 
+/// Every distinct namespace currently present on a `Concept` node. Used to seed
+/// the controlled vocabulary for per-topic namespace routing so the classifier
+/// reuses existing namespaces instead of minting near-duplicates.
+pub async fn list_namespaces(graph: &Graph) -> Result<Vec<String>> {
+    let q = query(
+        "MATCH (c:Concept)
+         WHERE c.namespace IS NOT NULL AND c.namespace <> ''
+         RETURN DISTINCT c.namespace AS ns
+         ORDER BY ns",
+    );
+    let mut result = graph.execute(q).await?;
+    let mut namespaces = Vec::new();
+    while let Some(row) = result.next().await? {
+        if let Ok(ns) = row.get::<String>("ns") {
+            namespaces.push(ns);
+        }
+    }
+    Ok(namespaces)
+}
+
 pub async fn update_concept_embedding(
     graph: &Graph,
     name: &str,

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1985,12 +1985,22 @@ async fn extract_concepts_for_session(
 /// `[extraction.routing]` `known_namespaces` allow-list, deduplicated
 /// (case-insensitive).
 ///
+/// `session_cwd` should be the session's own recorded working directory (see
+/// `Session.cwd` in graph.rs), so the ancestry walk is anchored on the
+/// project the session actually belongs to rather than the invoking
+/// process's cwd — batch enrichment and `--session <id>` calls may run from
+/// an unrelated directory. Pass `None` when the session has no recorded cwd.
+///
 /// This is deliberately NOT sourced from the whole graph: offering a peer
 /// project's namespace as vocab is exactly what let a drifting session route a
 /// concept into another project. Ancestry + allow-list is the only set the
 /// classifier ever sees, and [`route_namespace`] is constrained to the same
 /// set, so cross-project writes are impossible by construction.
-fn known_namespace_vocabulary(namespace: &str, routing: &config::RoutingConfig) -> Vec<String> {
+fn known_namespace_vocabulary(
+    namespace: &str,
+    session_cwd: Option<&Path>,
+    routing: &config::RoutingConfig,
+) -> Vec<String> {
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut vocab: Vec<String> = Vec::new();
     let mut push = |ns: &str| {
@@ -1999,7 +2009,7 @@ fn known_namespace_vocabulary(namespace: &str, routing: &config::RoutingConfig) 
             vocab.push(ns.to_string());
         }
     };
-    for ns in config::resolve_namespaces(namespace) {
+    for ns in config::resolve_namespaces(namespace, session_cwd) {
         push(&ns);
     }
     for ns in &routing.known_namespaces {
@@ -2016,17 +2026,19 @@ pub async fn enrich_session(session_id: &str, namespace: &str, force: bool) -> R
 
     let mut stats = EnrichStats::default();
 
-    if !force {
-        let mut r = graph_conn
-            .execute(
-                neo4rs::query(
-                    "MATCH (s:Session {session_id: $id})
-                 RETURN s.enriched_at AS enriched_at, s.deep_indexed_at AS deep_at",
-                )
-                .param("id", session_id),
+    let mut r = graph_conn
+        .execute(
+            neo4rs::query(
+                "MATCH (s:Session {session_id: $id})
+                 RETURN s.enriched_at AS enriched_at, s.deep_indexed_at AS deep_at, s.cwd AS cwd",
             )
-            .await?;
-        if let Some(row) = r.next().await? {
+            .param("id", session_id),
+        )
+        .await?;
+    let mut session_cwd: Option<String> = None;
+    if let Some(row) = r.next().await? {
+        session_cwd = row.get("cwd").ok().filter(|c: &String| !c.is_empty());
+        if !force {
             let enriched: Option<String> = row.get("enriched_at").ok();
             let deep: Option<String> = row.get("deep_at").ok();
             if let (Some(e), Some(d)) = (enriched.as_ref(), deep.as_ref()) {
@@ -2040,7 +2052,11 @@ pub async fn enrich_session(session_id: &str, namespace: &str, force: bool) -> R
     }
 
     let vocab = if extraction.routing.enabled {
-        known_namespace_vocabulary(namespace, &extraction.routing)
+        known_namespace_vocabulary(
+            namespace,
+            session_cwd.as_deref().map(Path::new),
+            &extraction.routing,
+        )
     } else {
         Vec::new()
     };
@@ -2150,7 +2166,7 @@ pub async fn enrich_all(namespaces: &[String], limit: usize, force: bool) -> Res
                     "MATCH (s:Session)
                  WHERE s.deep_indexed_at IS NOT NULL
                    AND ($all_ns OR s.namespace IN $namespaces)
-                 RETURN s.session_id AS id, s.namespace AS ns
+                 RETURN s.session_id AS id, s.namespace AS ns, s.cwd AS cwd
                  ORDER BY s.deep_indexed_at DESC
                  LIMIT $limit",
                 )
@@ -2166,8 +2182,9 @@ pub async fn enrich_all(namespaces: &[String], limit: usize, force: bool) -> Res
         while let Some(row) = result.next().await? {
             let id: String = row.get("id").unwrap_or_default();
             let ns: String = row.get("ns").unwrap_or_default();
+            let cwd: String = row.get("cwd").unwrap_or_default();
             if !id.is_empty() {
-                out.push((id, ns));
+                out.push((id, ns, cwd));
             }
         }
         out
@@ -2177,13 +2194,16 @@ pub async fn enrich_all(namespaces: &[String], limit: usize, force: bool) -> Res
         for id in ids {
             let mut r = graph_conn
                 .execute(
-                    neo4rs::query("MATCH (s:Session {session_id: $id}) RETURN s.namespace AS ns")
-                        .param("id", id.as_str()),
+                    neo4rs::query(
+                        "MATCH (s:Session {session_id: $id}) RETURN s.namespace AS ns, s.cwd AS cwd",
+                    )
+                    .param("id", id.as_str()),
                 )
                 .await?;
             if let Some(row) = r.next().await? {
                 let ns: String = row.get("ns").unwrap_or_default();
-                out.push((id, ns));
+                let cwd: String = row.get("cwd").unwrap_or_default();
+                out.push((id, ns, cwd));
             }
         }
         out
@@ -2198,12 +2218,15 @@ pub async fn enrich_all(namespaces: &[String], limit: usize, force: bool) -> Res
 
     let mut total = EnrichStats::default();
 
-    for (sid, ns) in &session_ids {
+    for (sid, ns, cwd) in &session_ids {
         let short = &sid[..8.min(sid.len())];
         // Vocab is scoped to THIS session's own namespace ancestry (+ allow-list),
-        // recomputed per session because a batch may span namespaces.
+        // recomputed per session because a batch may span namespaces. Anchored
+        // on the session's own recorded cwd, not the operator's, since a batch
+        // run's invoking process may sit in an unrelated directory.
+        let session_cwd = (!cwd.is_empty()).then(|| Path::new(cwd.as_str()));
         let vocab = if extraction.routing.enabled {
-            known_namespace_vocabulary(ns, &extraction.routing)
+            known_namespace_vocabulary(ns, session_cwd, &extraction.routing)
         } else {
             Vec::new()
         };
@@ -2594,11 +2617,60 @@ mod route_namespace_tests {
             enabled: true,
             known_namespaces: vec!["reference".to_string()],
         };
-        let vocab = known_namespace_vocabulary("reserve-padel-unresolved-xyz", &routing);
+        let vocab = known_namespace_vocabulary("reserve-padel-unresolved-xyz", None, &routing);
         assert!(vocab.iter().any(|n| n == "reserve-padel-unresolved-xyz"));
         assert!(vocab.iter().any(|n| n == "global"));
         assert!(vocab.iter().any(|n| n == "reference"));
         // A peer project the classifier might name is NOT offered as vocab.
         assert!(!vocab.iter().any(|n| n == "homeschool"));
+    }
+
+    #[test]
+    fn vocabulary_anchors_on_session_cwd_not_process_cwd() {
+        // A batch enrich run (or `--session <id>`) invokes this from wherever
+        // the operator happens to be, not from the session's own project
+        // directory. The ancestry walk must anchor on the session's recorded
+        // `cwd`, not `std::env::current_dir()`, or a parent namespace
+        // configured on disk silently drops out of the vocab.
+        let root = std::env::temp_dir().join(format!("c0-vocab-cwd-anchor-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let project = root.join("reserve-padel-cwd-anchor-test");
+        std::fs::create_dir_all(project.join(".c0")).expect("create .c0");
+        std::fs::write(
+            project.join(".c0/config.toml"),
+            "namespace = \"reserve-padel-cwd-anchor-test\"\nparent_namespace = \"solution-architect-cwd-anchor-test\"\n",
+        )
+        .expect("write config");
+
+        let routing = RoutingConfig {
+            enabled: true,
+            known_namespaces: Vec::new(),
+        };
+
+        // Anchored on the session's own cwd: the parent configured on disk
+        // is found and joins the ancestry.
+        let vocab = known_namespace_vocabulary(
+            "reserve-padel-cwd-anchor-test",
+            Some(project.as_path()),
+            &routing,
+        );
+        assert!(
+            vocab
+                .iter()
+                .any(|n| n == "solution-architect-cwd-anchor-test")
+        );
+
+        // No session cwd (falls back to this test process's own cwd, which is
+        // nowhere near the scratch project): the `.c0` config is never found,
+        // so the parent is silently absent from the vocab.
+        let vocab_unanchored =
+            known_namespace_vocabulary("reserve-padel-cwd-anchor-test", None, &routing);
+        assert!(
+            !vocab_unanchored
+                .iter()
+                .any(|n| n == "solution-architect-cwd-anchor-test")
+        );
+
+        std::fs::remove_dir_all(&root).ok();
     }
 }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -200,6 +200,20 @@ fn route_namespace(topic: Option<&str>, source: &str, known: &[String], allow_ne
     }
 }
 
+/// Record a namespace that `route_namespace` just minted or assigned into a
+/// running in-memory vocabulary so later calls in the same batch see it and
+/// reuse it instead of minting a near-duplicate. Case-insensitive dedup, no-op
+/// if `candidate` is already present.
+fn push_namespace_candidate(vocab: &mut Vec<String>, candidate: &str) {
+    let candidate = candidate.trim();
+    if candidate.is_empty() {
+        return;
+    }
+    if !vocab.iter().any(|existing| existing.eq_ignore_ascii_case(candidate)) {
+        vocab.push(candidate.to_string());
+    }
+}
+
 fn file_mtime_ms(path: &PathBuf) -> Option<u64> {
     std::fs::metadata(path)
         .ok()
@@ -1933,13 +1947,21 @@ async fn extract_concepts_full(
     let total = chunks.len();
     let mut merged: Vec<ExtractedConcept> = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // Grows as chunks are processed so a topic label proposed in an earlier
+    // chunk is visible to the classifier for later chunks in this same
+    // session, instead of every chunk seeing only the pre-run vocabulary.
+    let mut running_vocab: Vec<String> = known.map(<[String]>::to_vec).unwrap_or_default();
     for (i, chunk) in chunks.iter().enumerate() {
         if chunk.trim().is_empty() {
             continue;
         }
-        match extract_session_concepts(chunk, max_concepts, known).await {
+        let chunk_known = known.is_some().then_some(running_vocab.as_slice());
+        match extract_session_concepts(chunk, max_concepts, chunk_known).await {
             Ok(concepts) => {
                 for c in concepts {
+                    if let Some(topic) = c.topic.as_deref() {
+                        push_namespace_candidate(&mut running_vocab, topic);
+                    }
                     if seen.insert(c.name.clone()) {
                         merged.push(c);
                     }
@@ -2038,7 +2060,7 @@ pub async fn enrich_session(session_id: &str, namespace: &str, force: bool) -> R
         }
     }
 
-    let vocab = if extraction.per_topic_namespace {
+    let mut vocab = if extraction.per_topic_namespace {
         known_namespace_vocabulary(&graph_conn, &extraction).await
     } else {
         Vec::new()
@@ -2084,6 +2106,9 @@ pub async fn enrich_session(session_id: &str, namespace: &str, force: bool) -> R
         } else {
             namespace.to_string()
         };
+        if extraction.per_topic_namespace {
+            push_namespace_candidate(&mut vocab, &target_ns);
+        }
 
         let embedding = if let Some(ref client) = ollama {
             client
@@ -2200,17 +2225,17 @@ pub async fn enrich_all(namespaces: &[String], limit: usize, force: bool) -> Res
 
     println!("Enriching {} session(s)...", session_ids.len());
 
-    let vocab = if extraction.per_topic_namespace {
+    let mut vocab = if extraction.per_topic_namespace {
         known_namespace_vocabulary(&graph_conn, &extraction).await
     } else {
         Vec::new()
     };
-    let known = extraction.per_topic_namespace.then_some(vocab.as_slice());
 
     let mut total = EnrichStats::default();
 
     for (sid, ns) in &session_ids {
         let short = &sid[..8.min(sid.len())];
+        let known = extraction.per_topic_namespace.then_some(vocab.as_slice());
         let (concepts, text_len) = match extract_concepts_for_session(
             &graph_conn,
             sid,
@@ -2245,6 +2270,9 @@ pub async fn enrich_all(namespaces: &[String], limit: usize, force: bool) -> Res
             } else {
                 ns.clone()
             };
+            if extraction.per_topic_namespace {
+                push_namespace_candidate(&mut vocab, &target_ns);
+            }
 
             let embedding = if let Some(ref client) = ollama {
                 client
@@ -2482,7 +2510,7 @@ mod enrichment_tests {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod route_namespace_tests {
-    use super::route_namespace;
+    use super::{push_namespace_candidate, route_namespace};
 
     fn known() -> Vec<String> {
         vec![
@@ -2540,5 +2568,36 @@ mod route_namespace_tests {
         let empty: Vec<String> = Vec::new();
         assert_eq!(route_namespace(Some("issa"), "workspace", &empty, false), "workspace");
         assert_eq!(route_namespace(Some("issa"), "workspace", &empty, true), "issa");
+    }
+
+    #[test]
+    fn namespace_minted_for_first_item_is_seen_by_second_item_in_the_same_batch() {
+        // Simulates enrich_all's per-session loop: `vocab` starts from the
+        // pre-run graph vocabulary and must be refreshed in-place as each
+        // item mints a namespace, so later items in the same batch route
+        // into it instead of independently minting a near-duplicate.
+        let mut vocab = known();
+
+        let first_item_ns = route_namespace(Some("mlops"), "workspace-a", &vocab, true);
+        assert_eq!(first_item_ns, "mlops");
+        push_namespace_candidate(&mut vocab, &first_item_ns);
+        assert!(vocab.iter().any(|ns| ns.eq_ignore_ascii_case("mlops")));
+
+        // Second item's topic is a case-variant of the same freshly-minted
+        // namespace; it must snap onto "mlops" rather than minting "MLOps".
+        let second_item_ns = route_namespace(Some("MLOps"), "workspace-b", &vocab, true);
+        assert_eq!(second_item_ns, "mlops");
+    }
+
+    #[test]
+    fn push_namespace_candidate_dedupes_case_insensitively() {
+        let mut vocab = known();
+        push_namespace_candidate(&mut vocab, "c0");
+        push_namespace_candidate(&mut vocab, "C0");
+        push_namespace_candidate(&mut vocab, "  ");
+        assert_eq!(vocab, known());
+
+        push_namespace_candidate(&mut vocab, "mlops");
+        assert_eq!(vocab.last().map(String::as_str), Some("mlops"));
     }
 }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -165,6 +165,41 @@ fn derive_namespace(dir_name: &str) -> String {
         .to_string()
 }
 
+/// Decide the target namespace for a single extracted concept when per-topic
+/// routing is enabled.
+///
+/// - `topic`: the classifier's sanitized topic label (already lowercase
+///   kebab-case) or `None` when the model gave nothing usable.
+/// - `source`: the folder-derived namespace for the whole session/document —
+///   the legacy destination and the fallback here.
+/// - `known`: the controlled vocabulary (existing graph namespaces + configured
+///   `known_namespaces`), lowercased.
+/// - `allow_new`: whether an unrecognized topic may mint a brand-new namespace.
+///
+/// Fallback rules that keep the change safe and sprawl-free:
+/// - No topic → route to `source`.
+/// - Topic matches a known namespace (case-insensitive) → that namespace.
+/// - Topic is new and `allow_new` is true → the new topic namespace.
+/// - Topic is new and `allow_new` is false → route to `source`.
+fn route_namespace(topic: Option<&str>, source: &str, known: &[String], allow_new: bool) -> String {
+    let Some(topic) = topic.map(str::trim).filter(|t| !t.is_empty()) else {
+        return source.to_string();
+    };
+
+    if let Some(matched) = known
+        .iter()
+        .find(|ns| ns.eq_ignore_ascii_case(topic))
+    {
+        return matched.clone();
+    }
+
+    if allow_new {
+        topic.to_string()
+    } else {
+        source.to_string()
+    }
+}
+
 fn file_mtime_ms(path: &PathBuf) -> Option<u64> {
     std::fs::metadata(path)
         .ok()
@@ -1635,7 +1670,11 @@ fn parse_ollama_concepts(raw: &str, max: usize) -> Result<Vec<ExtractedConcept>>
             } else {
                 desc
             };
-            Some(ExtractedConcept { name, description })
+            Some(ExtractedConcept {
+                name,
+                description,
+                topic: crate::claude::sanitize_topic_label(c.topic.as_deref()),
+            })
         })
         .take(max)
         .collect();
@@ -1645,6 +1684,7 @@ fn parse_ollama_concepts(raw: &str, max: usize) -> Result<Vec<ExtractedConcept>>
 async fn extract_session_concepts(
     text: &str,
     max_concepts: usize,
+    known: Option<&[String]>,
 ) -> Result<Vec<ExtractedConcept>> {
     let semantic_config = config::SemanticConfig::load();
 
@@ -1657,6 +1697,8 @@ async fn extract_session_concepts(
     if client.provider_name() == "ollama" {
         let model_override = std::env::var("C0_ENRICH_MODEL").ok();
         let model = model_override.unwrap_or_else(|| client.model.clone());
+        // The Ollama enrichment path does not emit topic labels; per-topic
+        // routing degrades gracefully to source-namespace fallback here.
         return extract_session_concepts_ollama(
             &semantic_config.ollama_host,
             &model,
@@ -1666,7 +1708,14 @@ async fn extract_session_concepts(
         .await;
     }
 
-    client.extract_session_concepts(text, max_concepts).await
+    match known {
+        Some(vocab) => {
+            client
+                .extract_session_concepts_with_topics(text, max_concepts, vocab)
+                .await
+        }
+        None => client.extract_session_concepts(text, max_concepts).await,
+    }
 }
 
 /// Collapse a string to a single capped line for the signal block.
@@ -1849,6 +1898,7 @@ async fn extract_concepts_full(
     inputs: &EnrichmentInputs,
     budget: usize,
     max_concepts: usize,
+    known: Option<&[String]>,
 ) -> Result<Vec<ExtractedConcept>> {
     let signal = build_signal_block(
         &inputs.files,
@@ -1887,7 +1937,7 @@ async fn extract_concepts_full(
         if chunk.trim().is_empty() {
             continue;
         }
-        match extract_session_concepts(chunk, max_concepts).await {
+        match extract_session_concepts(chunk, max_concepts, known).await {
             Ok(concepts) => {
                 for c in concepts {
                     if seen.insert(c.name.clone()) {
@@ -1909,6 +1959,7 @@ async fn extract_concepts_for_session(
     session_id: &str,
     budget: usize,
     max_concepts: usize,
+    known: Option<&[String]>,
 ) -> Result<(Vec<ExtractedConcept>, usize)> {
     let inputs = graph::get_session_enrichment_inputs(graph_conn, session_id).await?;
     if inputs.turns.is_empty() && inputs.reflections.is_empty() {
@@ -1917,7 +1968,7 @@ async fn extract_concepts_for_session(
 
     if enrichment_full() {
         let total: usize = inputs.turns.iter().map(|t| t.text.len()).sum();
-        let concepts = extract_concepts_full(&inputs, budget, max_concepts).await?;
+        let concepts = extract_concepts_full(&inputs, budget, max_concepts, known).await?;
         Ok((concepts, total))
     } else {
         let text = build_enrichment_text(&inputs, budget);
@@ -1925,14 +1976,41 @@ async fn extract_concepts_for_session(
             return Ok((Vec::new(), 0));
         }
         let len = text.len();
-        let concepts = extract_session_concepts(&text, max_concepts).await?;
+        let concepts = extract_session_concepts(&text, max_concepts, known).await?;
         Ok((concepts, len))
     }
+}
+
+/// Assemble the controlled namespace vocabulary for per-topic routing: the
+/// namespaces already present on `Concept` nodes plus any configured in
+/// `[extraction] known_namespaces`, deduplicated (case-insensitive).
+async fn known_namespace_vocabulary(
+    graph_conn: &neo4rs::Graph,
+    extraction: &config::ExtractionConfig,
+) -> Vec<String> {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut vocab: Vec<String> = Vec::new();
+    let mut push = |ns: &str| {
+        let key = ns.to_lowercase();
+        if !ns.is_empty() && seen.insert(key) {
+            vocab.push(ns.to_string());
+        }
+    };
+    if let Ok(graph_namespaces) = graph::list_namespaces(graph_conn).await {
+        for ns in &graph_namespaces {
+            push(ns);
+        }
+    }
+    for ns in &extraction.known_namespaces {
+        push(ns);
+    }
+    vocab
 }
 
 pub async fn enrich_session(session_id: &str, namespace: &str, force: bool) -> Result<EnrichStats> {
     let graph_conn = graph::connect().await?;
     let semantic_config = config::SemanticConfig::load();
+    let extraction = config::ExtractionConfig::load();
     let ollama = embeddings::OllamaClient::from_config(&semantic_config);
 
     let mut stats = EnrichStats::default();
@@ -1960,11 +2038,19 @@ pub async fn enrich_session(session_id: &str, namespace: &str, force: bool) -> R
         }
     }
 
+    let vocab = if extraction.per_topic_namespace {
+        known_namespace_vocabulary(&graph_conn, &extraction).await
+    } else {
+        Vec::new()
+    };
+    let known = extraction.per_topic_namespace.then_some(vocab.as_slice());
+
     let (concepts, text_len) = match extract_concepts_for_session(
         &graph_conn,
         session_id,
         enrichment_text_budget(),
         enrichment_max_concepts(),
+        known,
     )
     .await
     {
@@ -1988,6 +2074,17 @@ pub async fn enrich_session(session_id: &str, namespace: &str, force: bool) -> R
     println!("  extracted {} concept(s)", concepts.len());
 
     for concept in &concepts {
+        let target_ns = if extraction.per_topic_namespace {
+            route_namespace(
+                concept.topic.as_deref(),
+                namespace,
+                &vocab,
+                extraction.allow_new_namespaces,
+            )
+        } else {
+            namespace.to_string()
+        };
+
         let embedding = if let Some(ref client) = ollama {
             client
                 .embed(&format!("{}: {}", concept.name, concept.description))
@@ -2000,7 +2097,7 @@ pub async fn enrich_session(session_id: &str, namespace: &str, force: bool) -> R
         if let Err(e) = graph::add_concept(
             &graph_conn,
             &concept.name,
-            namespace,
+            &target_ns,
             Some(&concept.description),
             Some("session-enrichment"),
             None,
@@ -2016,7 +2113,7 @@ pub async fn enrich_session(session_id: &str, namespace: &str, force: bool) -> R
         stats.concepts_created += 1;
 
         if let Err(e) =
-            graph::link_concept_to_session(&graph_conn, &concept.name, namespace, session_id, 1)
+            graph::link_concept_to_session(&graph_conn, &concept.name, &target_ns, session_id, 1)
                 .await
         {
             eprintln!("  failed to link concept {}: {e}", concept.name);
@@ -2024,7 +2121,14 @@ pub async fn enrich_session(session_id: &str, namespace: &str, force: bool) -> R
             continue;
         }
         stats.concepts_linked += 1;
-        println!("  • {} — {}", concept.name, concept.description);
+        if extraction.per_topic_namespace && target_ns != namespace {
+            println!(
+                "  • [{target_ns}] {} — {}",
+                concept.name, concept.description
+            );
+        } else {
+            println!("  • {} — {}", concept.name, concept.description);
+        }
     }
 
     graph::mark_session_enriched(&graph_conn, session_id, stats.concepts_linked as i64).await?;
@@ -2040,6 +2144,7 @@ pub async fn enrich_session(session_id: &str, namespace: &str, force: bool) -> R
 pub async fn enrich_all(namespaces: &[String], limit: usize, force: bool) -> Result<EnrichStats> {
     let graph_conn = graph::connect().await?;
     let semantic_config = config::SemanticConfig::load();
+    let extraction = config::ExtractionConfig::load();
     let ollama = embeddings::OllamaClient::from_config(&semantic_config);
 
     let session_ids = if force {
@@ -2095,6 +2200,13 @@ pub async fn enrich_all(namespaces: &[String], limit: usize, force: bool) -> Res
 
     println!("Enriching {} session(s)...", session_ids.len());
 
+    let vocab = if extraction.per_topic_namespace {
+        known_namespace_vocabulary(&graph_conn, &extraction).await
+    } else {
+        Vec::new()
+    };
+    let known = extraction.per_topic_namespace.then_some(vocab.as_slice());
+
     let mut total = EnrichStats::default();
 
     for (sid, ns) in &session_ids {
@@ -2104,6 +2216,7 @@ pub async fn enrich_all(namespaces: &[String], limit: usize, force: bool) -> Res
             sid,
             enrichment_text_budget(),
             enrichment_max_concepts(),
+            known,
         )
         .await
         {
@@ -2122,6 +2235,17 @@ pub async fn enrich_all(namespaces: &[String], limit: usize, force: bool) -> Res
 
         let mut linked = 0u32;
         for concept in &concepts {
+            let target_ns = if extraction.per_topic_namespace {
+                route_namespace(
+                    concept.topic.as_deref(),
+                    ns,
+                    &vocab,
+                    extraction.allow_new_namespaces,
+                )
+            } else {
+                ns.clone()
+            };
+
             let embedding = if let Some(ref client) = ollama {
                 client
                     .embed(&format!("{}: {}", concept.name, concept.description))
@@ -2133,7 +2257,7 @@ pub async fn enrich_all(namespaces: &[String], limit: usize, force: bool) -> Res
             let added = graph::add_concept(
                 &graph_conn,
                 &concept.name,
-                ns,
+                &target_ns,
                 Some(&concept.description),
                 Some("session-enrichment"),
                 None,
@@ -2146,7 +2270,7 @@ pub async fn enrich_all(namespaces: &[String], limit: usize, force: bool) -> Res
                 continue;
             }
             total.concepts_created += 1;
-            if graph::link_concept_to_session(&graph_conn, &concept.name, ns, sid, 1)
+            if graph::link_concept_to_session(&graph_conn, &concept.name, &target_ns, sid, 1)
                 .await
                 .is_ok()
             {
@@ -2352,5 +2476,69 @@ mod enrichment_tests {
         assert!(text.contains("src/sessions.rs"));
         assert!(text.contains("let's optimize"));
         assert!(text.len() <= 8_000);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod route_namespace_tests {
+    use super::route_namespace;
+
+    fn known() -> Vec<String> {
+        vec![
+            "c0".to_string(),
+            "issa".to_string(),
+            "homeschool".to_string(),
+        ]
+    }
+
+    #[test]
+    fn no_topic_falls_back_to_source() {
+        assert_eq!(route_namespace(None, "workspace", &known(), true), "workspace");
+        assert_eq!(route_namespace(Some(""), "workspace", &known(), true), "workspace");
+        assert_eq!(
+            route_namespace(Some("   "), "workspace", &known(), true),
+            "workspace"
+        );
+    }
+
+    #[test]
+    fn topic_matching_known_namespace_routes_there() {
+        assert_eq!(route_namespace(Some("issa"), "workspace", &known(), false), "issa");
+        assert_eq!(route_namespace(Some("c0"), "workspace", &known(), false), "c0");
+        assert_eq!(
+            route_namespace(Some("homeschool"), "workspace", &known(), false),
+            "homeschool"
+        );
+    }
+
+    #[test]
+    fn known_match_is_case_insensitive_and_returns_canonical_form() {
+        // The classifier may upper-case; we snap to the canonical stored form.
+        assert_eq!(route_namespace(Some("ISSA"), "workspace", &known(), false), "issa");
+        assert_eq!(route_namespace(Some("C0"), "workspace", &known(), true), "c0");
+    }
+
+    #[test]
+    fn new_topic_without_allow_new_falls_back_to_source() {
+        assert_eq!(
+            route_namespace(Some("brand-new-topic"), "workspace", &known(), false),
+            "workspace"
+        );
+    }
+
+    #[test]
+    fn new_topic_with_allow_new_mints_the_topic_namespace() {
+        assert_eq!(
+            route_namespace(Some("brand-new-topic"), "workspace", &known(), true),
+            "brand-new-topic"
+        );
+    }
+
+    #[test]
+    fn empty_vocabulary_defers_to_allow_new_flag() {
+        let empty: Vec<String> = Vec::new();
+        assert_eq!(route_namespace(Some("issa"), "workspace", &empty, false), "workspace");
+        assert_eq!(route_namespace(Some("issa"), "workspace", &empty, true), "issa");
     }
 }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -186,10 +186,7 @@ fn route_namespace(topic: Option<&str>, source: &str, known: &[String], allow_ne
         return source.to_string();
     };
 
-    if let Some(matched) = known
-        .iter()
-        .find(|ns| ns.eq_ignore_ascii_case(topic))
-    {
+    if let Some(matched) = known.iter().find(|ns| ns.eq_ignore_ascii_case(topic)) {
         return matched.clone();
     }
 
@@ -209,7 +206,10 @@ fn push_namespace_candidate(vocab: &mut Vec<String>, candidate: &str) {
     if candidate.is_empty() {
         return;
     }
-    if !vocab.iter().any(|existing| existing.eq_ignore_ascii_case(candidate)) {
+    if !vocab
+        .iter()
+        .any(|existing| existing.eq_ignore_ascii_case(candidate))
+    {
         vocab.push(candidate.to_string());
     }
 }
@@ -2522,8 +2522,14 @@ mod route_namespace_tests {
 
     #[test]
     fn no_topic_falls_back_to_source() {
-        assert_eq!(route_namespace(None, "workspace", &known(), true), "workspace");
-        assert_eq!(route_namespace(Some(""), "workspace", &known(), true), "workspace");
+        assert_eq!(
+            route_namespace(None, "workspace", &known(), true),
+            "workspace"
+        );
+        assert_eq!(
+            route_namespace(Some(""), "workspace", &known(), true),
+            "workspace"
+        );
         assert_eq!(
             route_namespace(Some("   "), "workspace", &known(), true),
             "workspace"
@@ -2532,8 +2538,14 @@ mod route_namespace_tests {
 
     #[test]
     fn topic_matching_known_namespace_routes_there() {
-        assert_eq!(route_namespace(Some("issa"), "workspace", &known(), false), "issa");
-        assert_eq!(route_namespace(Some("c0"), "workspace", &known(), false), "c0");
+        assert_eq!(
+            route_namespace(Some("issa"), "workspace", &known(), false),
+            "issa"
+        );
+        assert_eq!(
+            route_namespace(Some("c0"), "workspace", &known(), false),
+            "c0"
+        );
         assert_eq!(
             route_namespace(Some("homeschool"), "workspace", &known(), false),
             "homeschool"
@@ -2543,8 +2555,14 @@ mod route_namespace_tests {
     #[test]
     fn known_match_is_case_insensitive_and_returns_canonical_form() {
         // The classifier may upper-case; we snap to the canonical stored form.
-        assert_eq!(route_namespace(Some("ISSA"), "workspace", &known(), false), "issa");
-        assert_eq!(route_namespace(Some("C0"), "workspace", &known(), true), "c0");
+        assert_eq!(
+            route_namespace(Some("ISSA"), "workspace", &known(), false),
+            "issa"
+        );
+        assert_eq!(
+            route_namespace(Some("C0"), "workspace", &known(), true),
+            "c0"
+        );
     }
 
     #[test]
@@ -2566,8 +2584,14 @@ mod route_namespace_tests {
     #[test]
     fn empty_vocabulary_defers_to_allow_new_flag() {
         let empty: Vec<String> = Vec::new();
-        assert_eq!(route_namespace(Some("issa"), "workspace", &empty, false), "workspace");
-        assert_eq!(route_namespace(Some("issa"), "workspace", &empty, true), "issa");
+        assert_eq!(
+            route_namespace(Some("issa"), "workspace", &empty, false),
+            "workspace"
+        );
+        assert_eq!(
+            route_namespace(Some("issa"), "workspace", &empty, true),
+            "issa"
+        );
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -165,53 +165,37 @@ fn derive_namespace(dir_name: &str) -> String {
         .to_string()
 }
 
-/// Decide the target namespace for a single extracted concept when per-topic
-/// routing is enabled.
+/// Choose the destination namespace for one extracted concept under per-topic
+/// routing.
 ///
 /// - `topic`: the classifier's sanitized topic label (already lowercase
 ///   kebab-case) or `None` when the model gave nothing usable.
 /// - `source`: the folder-derived namespace for the whole session/document —
 ///   the legacy destination and the fallback here.
-/// - `known`: the controlled vocabulary (existing graph namespaces + configured
-///   `known_namespaces`), lowercased.
-/// - `allow_new`: whether an unrecognized topic may mint a brand-new namespace.
+/// - `allowed`: the controlled set the concept may be routed into — the
+///   session's OWN namespace ancestry (self + parent chain + `global`) plus the
+///   configured `[extraction.routing] known_namespaces` allow-list. This set
+///   NEVER contains a peer project's namespace.
 ///
-/// Fallback rules that keep the change safe and sprawl-free:
+/// Ancestry-scoped routing (Doug's #74 review). A topic only means "which of
+/// *my* ancestor buckets does this belong in":
 /// - No topic → route to `source`.
-/// - Topic matches a known namespace (case-insensitive) → that namespace.
-/// - Topic is new and `allow_new` is true → the new topic namespace.
-/// - Topic is new and `allow_new` is false → route to `source`.
-fn route_namespace(topic: Option<&str>, source: &str, known: &[String], allow_new: bool) -> String {
+/// - Topic matches an allowed namespace (case-insensitive) → that namespace.
+/// - Topic matches nothing in `allowed` → route to `source`.
+///
+/// A topic naming a namespace outside `allowed` (e.g. a peer project the
+/// conversation drifted onto) can never route there — cross-project writes are
+/// impossible by construction, not merely discouraged by the prompt.
+fn route_namespace(topic: Option<&str>, source: &str, allowed: &[String]) -> String {
     let Some(topic) = topic.map(str::trim).filter(|t| !t.is_empty()) else {
         return source.to_string();
     };
 
-    if let Some(matched) = known.iter().find(|ns| ns.eq_ignore_ascii_case(topic)) {
-        return matched.clone();
-    }
-
-    if allow_new {
-        topic.to_string()
-    } else {
-        source.to_string()
-    }
-}
-
-/// Record a namespace that `route_namespace` just minted or assigned into a
-/// running in-memory vocabulary so later calls in the same batch see it and
-/// reuse it instead of minting a near-duplicate. Case-insensitive dedup, no-op
-/// if `candidate` is already present.
-fn push_namespace_candidate(vocab: &mut Vec<String>, candidate: &str) {
-    let candidate = candidate.trim();
-    if candidate.is_empty() {
-        return;
-    }
-    if !vocab
+    allowed
         .iter()
-        .any(|existing| existing.eq_ignore_ascii_case(candidate))
-    {
-        vocab.push(candidate.to_string());
-    }
+        .find(|ns| ns.eq_ignore_ascii_case(topic))
+        .cloned()
+        .unwrap_or_else(|| source.to_string())
 }
 
 fn file_mtime_ms(path: &PathBuf) -> Option<u64> {
@@ -1947,21 +1931,13 @@ async fn extract_concepts_full(
     let total = chunks.len();
     let mut merged: Vec<ExtractedConcept> = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    // Grows as chunks are processed so a topic label proposed in an earlier
-    // chunk is visible to the classifier for later chunks in this same
-    // session, instead of every chunk seeing only the pre-run vocabulary.
-    let mut running_vocab: Vec<String> = known.map(<[String]>::to_vec).unwrap_or_default();
     for (i, chunk) in chunks.iter().enumerate() {
         if chunk.trim().is_empty() {
             continue;
         }
-        let chunk_known = known.is_some().then_some(running_vocab.as_slice());
-        match extract_session_concepts(chunk, max_concepts, chunk_known).await {
+        match extract_session_concepts(chunk, max_concepts, known).await {
             Ok(concepts) => {
                 for c in concepts {
-                    if let Some(topic) = c.topic.as_deref() {
-                        push_namespace_candidate(&mut running_vocab, topic);
-                    }
                     if seen.insert(c.name.clone()) {
                         merged.push(c);
                     }
@@ -2003,13 +1979,18 @@ async fn extract_concepts_for_session(
     }
 }
 
-/// Assemble the controlled namespace vocabulary for per-topic routing: the
-/// namespaces already present on `Concept` nodes plus any configured in
-/// `[extraction] known_namespaces`, deduplicated (case-insensitive).
-async fn known_namespace_vocabulary(
-    graph_conn: &neo4rs::Graph,
-    extraction: &config::ExtractionConfig,
-) -> Vec<String> {
+/// Assemble the controlled namespace vocabulary for per-topic routing, scoped
+/// to the session's OWN namespace ancestry via `config::resolve_namespaces`
+/// (self, parent chain, and `global`) UNION the configured
+/// `[extraction.routing]` `known_namespaces` allow-list, deduplicated
+/// (case-insensitive).
+///
+/// This is deliberately NOT sourced from the whole graph: offering a peer
+/// project's namespace as vocab is exactly what let a drifting session route a
+/// concept into another project. Ancestry + allow-list is the only set the
+/// classifier ever sees, and [`route_namespace`] is constrained to the same
+/// set, so cross-project writes are impossible by construction.
+fn known_namespace_vocabulary(namespace: &str, routing: &config::RoutingConfig) -> Vec<String> {
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut vocab: Vec<String> = Vec::new();
     let mut push = |ns: &str| {
@@ -2018,12 +1999,10 @@ async fn known_namespace_vocabulary(
             vocab.push(ns.to_string());
         }
     };
-    if let Ok(graph_namespaces) = graph::list_namespaces(graph_conn).await {
-        for ns in &graph_namespaces {
-            push(ns);
-        }
+    for ns in config::resolve_namespaces(namespace) {
+        push(&ns);
     }
-    for ns in &extraction.known_namespaces {
+    for ns in &routing.known_namespaces {
         push(ns);
     }
     vocab
@@ -2060,12 +2039,12 @@ pub async fn enrich_session(session_id: &str, namespace: &str, force: bool) -> R
         }
     }
 
-    let mut vocab = if extraction.per_topic_namespace {
-        known_namespace_vocabulary(&graph_conn, &extraction).await
+    let vocab = if extraction.routing.enabled {
+        known_namespace_vocabulary(namespace, &extraction.routing)
     } else {
         Vec::new()
     };
-    let known = extraction.per_topic_namespace.then_some(vocab.as_slice());
+    let known = extraction.routing.enabled.then_some(vocab.as_slice());
 
     let (concepts, text_len) = match extract_concepts_for_session(
         &graph_conn,
@@ -2096,19 +2075,11 @@ pub async fn enrich_session(session_id: &str, namespace: &str, force: bool) -> R
     println!("  extracted {} concept(s)", concepts.len());
 
     for concept in &concepts {
-        let target_ns = if extraction.per_topic_namespace {
-            route_namespace(
-                concept.topic.as_deref(),
-                namespace,
-                &vocab,
-                extraction.allow_new_namespaces,
-            )
+        let target_ns = if extraction.routing.enabled {
+            route_namespace(concept.topic.as_deref(), namespace, &vocab)
         } else {
             namespace.to_string()
         };
-        if extraction.per_topic_namespace {
-            push_namespace_candidate(&mut vocab, &target_ns);
-        }
 
         let embedding = if let Some(ref client) = ollama {
             client
@@ -2146,7 +2117,7 @@ pub async fn enrich_session(session_id: &str, namespace: &str, force: bool) -> R
             continue;
         }
         stats.concepts_linked += 1;
-        if extraction.per_topic_namespace && target_ns != namespace {
+        if extraction.routing.enabled && target_ns != namespace {
             println!(
                 "  • [{target_ns}] {} — {}",
                 concept.name, concept.description
@@ -2225,17 +2196,18 @@ pub async fn enrich_all(namespaces: &[String], limit: usize, force: bool) -> Res
 
     println!("Enriching {} session(s)...", session_ids.len());
 
-    let mut vocab = if extraction.per_topic_namespace {
-        known_namespace_vocabulary(&graph_conn, &extraction).await
-    } else {
-        Vec::new()
-    };
-
     let mut total = EnrichStats::default();
 
     for (sid, ns) in &session_ids {
         let short = &sid[..8.min(sid.len())];
-        let known = extraction.per_topic_namespace.then_some(vocab.as_slice());
+        // Vocab is scoped to THIS session's own namespace ancestry (+ allow-list),
+        // recomputed per session because a batch may span namespaces.
+        let vocab = if extraction.routing.enabled {
+            known_namespace_vocabulary(ns, &extraction.routing)
+        } else {
+            Vec::new()
+        };
+        let known = extraction.routing.enabled.then_some(vocab.as_slice());
         let (concepts, text_len) = match extract_concepts_for_session(
             &graph_conn,
             sid,
@@ -2260,19 +2232,11 @@ pub async fn enrich_all(namespaces: &[String], limit: usize, force: bool) -> Res
 
         let mut linked = 0u32;
         for concept in &concepts {
-            let target_ns = if extraction.per_topic_namespace {
-                route_namespace(
-                    concept.topic.as_deref(),
-                    ns,
-                    &vocab,
-                    extraction.allow_new_namespaces,
-                )
+            let target_ns = if extraction.routing.enabled {
+                route_namespace(concept.topic.as_deref(), ns, &vocab)
             } else {
                 ns.clone()
             };
-            if extraction.per_topic_namespace {
-                push_namespace_candidate(&mut vocab, &target_ns);
-            }
 
             let embedding = if let Some(ref client) = ollama {
                 client
@@ -2510,118 +2474,131 @@ mod enrichment_tests {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod route_namespace_tests {
-    use super::{push_namespace_candidate, route_namespace};
+    use super::{known_namespace_vocabulary, route_namespace};
+    use crate::config::RoutingConfig;
 
-    fn known() -> Vec<String> {
+    /// The controlled set a session may route into: its own ancestry
+    /// (self `reserve-padel` + parent `solution-architect` + `global`) plus
+    /// one explicitly allow-listed cross-cutting bucket (`reference`). Never
+    /// contains a peer project namespace (`homeschool`, `some-other-client`).
+    fn allowed() -> Vec<String> {
         vec![
-            "c0".to_string(),
-            "issa".to_string(),
-            "homeschool".to_string(),
+            "reserve-padel".to_string(),
+            "solution-architect".to_string(),
+            "global".to_string(),
+            "reference".to_string(),
         ]
     }
 
     #[test]
     fn no_topic_falls_back_to_source() {
         assert_eq!(
-            route_namespace(None, "workspace", &known(), true),
-            "workspace"
+            route_namespace(None, "reserve-padel", &allowed()),
+            "reserve-padel"
         );
         assert_eq!(
-            route_namespace(Some(""), "workspace", &known(), true),
-            "workspace"
+            route_namespace(Some(""), "reserve-padel", &allowed()),
+            "reserve-padel"
         );
         assert_eq!(
-            route_namespace(Some("   "), "workspace", &known(), true),
-            "workspace"
+            route_namespace(Some("   "), "reserve-padel", &allowed()),
+            "reserve-padel"
         );
     }
 
     #[test]
-    fn topic_matching_known_namespace_routes_there() {
+    fn topic_naming_own_source_namespace_routes_there() {
         assert_eq!(
-            route_namespace(Some("issa"), "workspace", &known(), false),
-            "issa"
-        );
-        assert_eq!(
-            route_namespace(Some("c0"), "workspace", &known(), false),
-            "c0"
-        );
-        assert_eq!(
-            route_namespace(Some("homeschool"), "workspace", &known(), false),
-            "homeschool"
+            route_namespace(Some("reserve-padel"), "reserve-padel", &allowed()),
+            "reserve-padel"
         );
     }
 
     #[test]
-    fn known_match_is_case_insensitive_and_returns_canonical_form() {
+    fn topic_naming_a_parent_namespace_routes_there() {
+        // "which of MY ancestor buckets does this belong in": a concept the
+        // classifier tags with the parent namespace is written into the parent,
+        // which is already searched via the ancestry walk.
+        assert_eq!(
+            route_namespace(Some("solution-architect"), "reserve-padel", &allowed()),
+            "solution-architect"
+        );
+        assert_eq!(
+            route_namespace(Some("global"), "reserve-padel", &allowed()),
+            "global"
+        );
+    }
+
+    #[test]
+    fn topic_naming_an_allow_listed_bucket_routes_there() {
+        assert_eq!(
+            route_namespace(Some("reference"), "reserve-padel", &allowed()),
+            "reference"
+        );
+    }
+
+    #[test]
+    fn cross_project_write_is_impossible_by_construction() {
+        // THE core guarantee Doug required. A session in `reserve-padel` whose
+        // conversation drifted toward another client cannot route a concept into
+        // that peer project's namespace: a topic naming a NON-ancestor,
+        // non-allow-listed namespace falls back to the source, never the peer.
+        assert_eq!(
+            route_namespace(Some("homeschool"), "reserve-padel", &allowed()),
+            "reserve-padel"
+        );
+        assert_eq!(
+            route_namespace(Some("some-other-client"), "reserve-padel", &allowed()),
+            "reserve-padel"
+        );
+        // Even an arbitrary freshly-invented label cannot mint outside ancestry.
+        assert_eq!(
+            route_namespace(Some("brand-new-topic"), "reserve-padel", &allowed()),
+            "reserve-padel"
+        );
+    }
+
+    #[test]
+    fn allowed_match_is_case_insensitive_and_returns_canonical_form() {
         // The classifier may upper-case; we snap to the canonical stored form.
         assert_eq!(
-            route_namespace(Some("ISSA"), "workspace", &known(), false),
-            "issa"
+            route_namespace(Some("SOLUTION-ARCHITECT"), "reserve-padel", &allowed()),
+            "solution-architect"
         );
         assert_eq!(
-            route_namespace(Some("C0"), "workspace", &known(), true),
-            "c0"
+            route_namespace(Some("Reference"), "reserve-padel", &allowed()),
+            "reference"
         );
     }
 
     #[test]
-    fn new_topic_without_allow_new_falls_back_to_source() {
-        assert_eq!(
-            route_namespace(Some("brand-new-topic"), "workspace", &known(), false),
-            "workspace"
-        );
-    }
-
-    #[test]
-    fn new_topic_with_allow_new_mints_the_topic_namespace() {
-        assert_eq!(
-            route_namespace(Some("brand-new-topic"), "workspace", &known(), true),
-            "brand-new-topic"
-        );
-    }
-
-    #[test]
-    fn empty_vocabulary_defers_to_allow_new_flag() {
+    fn empty_allowed_set_always_falls_back_to_source() {
         let empty: Vec<String> = Vec::new();
         assert_eq!(
-            route_namespace(Some("issa"), "workspace", &empty, false),
-            "workspace"
+            route_namespace(Some("solution-architect"), "reserve-padel", &empty),
+            "reserve-padel"
         );
         assert_eq!(
-            route_namespace(Some("issa"), "workspace", &empty, true),
-            "issa"
+            route_namespace(Some("anything"), "reserve-padel", &empty),
+            "reserve-padel"
         );
     }
 
     #[test]
-    fn namespace_minted_for_first_item_is_seen_by_second_item_in_the_same_batch() {
-        // Simulates enrich_all's per-session loop: `vocab` starts from the
-        // pre-run graph vocabulary and must be refreshed in-place as each
-        // item mints a namespace, so later items in the same batch route
-        // into it instead of independently minting a near-duplicate.
-        let mut vocab = known();
-
-        let first_item_ns = route_namespace(Some("mlops"), "workspace-a", &vocab, true);
-        assert_eq!(first_item_ns, "mlops");
-        push_namespace_candidate(&mut vocab, &first_item_ns);
-        assert!(vocab.iter().any(|ns| ns.eq_ignore_ascii_case("mlops")));
-
-        // Second item's topic is a case-variant of the same freshly-minted
-        // namespace; it must snap onto "mlops" rather than minting "MLOps".
-        let second_item_ns = route_namespace(Some("MLOps"), "workspace-b", &vocab, true);
-        assert_eq!(second_item_ns, "mlops");
-    }
-
-    #[test]
-    fn push_namespace_candidate_dedupes_case_insensitively() {
-        let mut vocab = known();
-        push_namespace_candidate(&mut vocab, "c0");
-        push_namespace_candidate(&mut vocab, "C0");
-        push_namespace_candidate(&mut vocab, "  ");
-        assert_eq!(vocab, known());
-
-        push_namespace_candidate(&mut vocab, "mlops");
-        assert_eq!(vocab.last().map(String::as_str), Some("mlops"));
+    fn vocabulary_is_scoped_to_ancestry_plus_allowlist_never_peers() {
+        // `known_namespace_vocabulary` for a namespace not resolvable on disk
+        // falls back to [self, global]; the configured allow-list is merged in,
+        // but no arbitrary peer namespace ever appears (there is no whole-graph
+        // source anymore). This is the vocab half of the same guarantee.
+        let routing = RoutingConfig {
+            enabled: true,
+            known_namespaces: vec!["reference".to_string()],
+        };
+        let vocab = known_namespace_vocabulary("reserve-padel-unresolved-xyz", &routing);
+        assert!(vocab.iter().any(|n| n == "reserve-padel-unresolved-xyz"));
+        assert!(vocab.iter().any(|n| n == "global"));
+        assert!(vocab.iter().any(|n| n == "reference"));
+        // A peer project the classifier might name is NOT offered as vocab.
+        assert!(!vocab.iter().any(|n| n == "homeschool"));
     }
 }


### PR DESCRIPTION
## What Changed

- Add opt-in `[extraction.routing]` config (`enabled`, `known_namespaces`) and a `RoutingConfig`/`RoutingSettings` pair so per-topic namespace routing can be toggled without touching legacy behavior.
- Add `config::resolve_namespaces` to compute a session's own namespace ancestry (self, parent chain via `.c0/config.toml`, and `global`) anchored on the session's recorded `cwd` rather than the invoking process's cwd, and use it in `sessions.rs` to build a controlled per-session vocabulary (`known_namespace_vocabulary`) that also merges in the `known_namespaces` allow-list.
- Extend concept extraction (`claude.rs`) with a topic-aware prompt/schema variant (`extract_session_concepts_with_topics`) and `sanitize_topic_label` to normalize classifier-proposed topic labels into safe kebab-case tokens; `ExtractedConcept` gains an optional `topic` field.
- Add `route_namespace` in `sessions.rs` to snap each concept's topic onto the session's allowed-vocabulary set (case-insensitive), falling back to the source namespace when the topic is missing or names a namespace outside the allowed set, so cross-project writes are impossible by construction; wire this through `enrich_session` and `enrich_all`, including per-session vocab recomputation during batch enrichment.

## Risk Assessment

✅ Low: The fix-round commit correctly anchors namespace ancestry resolution on the session's own recorded cwd (a pre-existing, always-populated graph field) instead of the process cwd, is contained to the single call site that needed it, preserves prior behavior for sessions without a recorded cwd, and is backed by a real filesystem-exercising regression test.

## Testing

This is a backend Rust library/CLI change (session concept-extraction routing logic) with no rendered UI surface, so no screenshot/GIF evidence applies. The targeted test `sessions::route_namespace_tests::vocabulary_anchors_on_session_cwd_not_process_cwd` is a real filesystem-based integration test — it writes an actual `.c0/config.toml` to a scratch directory and calls the real production call chain (`known_namespace_vocabulary` → `config::resolve_namespaces` → `find_namespace_dir`), asserting the parent namespace is found when anchored on a session's recorded cwd and silently dropped when anchored on the process cwd instead. I confirmed this isn't a vacuous test by reading the pre-fix code at commit e1fc6d3, where `resolve_namespaces` hard-coded `std::env::current_dir()` with no way to anchor elsewhere — exactly the bug the recorded review decision described. All 16 targeted tests across sessions.rs, claude.rs, and config.rs pass, and the working tree is unchanged/clean.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"13da02fe858547aeb64e8f503afb0deed84ce127","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/claude.rs` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/config.rs:513` - resolve_namespaces(namespace) resolves a session&#39;s ancestry by walking up from std::env::current_dir() (via find_namespace_dir) looking for a `.c0/config.toml` whose `namespace` field matches the given name, then falls back to the home `~/.c0`. This only succeeds when the *invoking process&#39;s* cwd happens to sit inside (or at) the target namespace&#39;s own project directory tree. But callers in sessions.rs invoke it keyed on the *session&#39;s* namespace, not the operator&#39;s cwd: enrich_all (sessions.rs:2206, looping over `(sid, ns)` pairs whose own comment at sessions.rs:2203-2204 says &#34;a batch may span namespaces&#34;) and enrich_session (sessions.rs:2043, called from main.rs:1072 with `session_ns` fetched from the graph for an arbitrary session id, independent of cwd). Concrete failing case: session A belongs to namespace `reserve-padel` with `parent_namespace = &#34;solution-architect&#34;` configured on disk; operator runs `c0 sessions enrich --all` (or `--session &lt;id&gt;`) from an unrelated directory (home, a different project, a cron job&#39;s cwd). `find_namespace_dir(&#34;reserve-padel&#34;, cwd)` walks up from the unrelated cwd, never finds `reserve-padel`&#39;s `.c0/config.toml`, and resolve_namespaces silently falls into the &#39;unresolvable&#39; branch, returning only `[&#34;reserve-padel&#34;, &#34;global&#34;]` instead of `[&#34;reserve-padel&#34;, &#34;solution-architect&#34;, &#34;global&#34;]`. A concept the classifier correctly tags with topic `solution-architect` (the true parent, exactly the case route_namespace_tests::topic_naming_a_parent_namespace_routes_there validates) then fails the `allowed` membership check in route_namespace (sessions.rs) and silently falls back to routing into `reserve-padel` instead of the intended parent — a wrong routing decision made without any error, undermining the PR&#39;s stated purpose (&#34;scope per-topic routing to namespace ancestry&#34;) in exactly the batch/cross-namespace scenario its own inline comments anticipate. The data needed to fix this already exists: `Session` nodes store the session&#39;s real `cwd` (graph.rs:86, populated at ingestion), which is the correct directory to seed the `.c0` walk from — but it is never fetched or threaded into resolve_namespaces/known_namespace_vocabulary. It fails safe (falls back to the source namespace, never leaks into a peer project), so this is a correctness/quality gap rather than a security issue.

🔧 Fix: Anchor namespace ancestry resolution on session cwd, not process cwd
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo test --features sessions route_namespace_tests -- --nocapture (9/9 passed)`
- `cargo test --features sessions sanitize_topic_label (3/3 passed)`
- `cargo test --features sessions parse_session_concepts (2/2 passed)`
- `cargo test config:: (2/2 passed, pre-existing NamespaceContext tests unaffected)`
- `Read src/config.rs at commit e1fc6d3 (pre-fix) to confirm resolve_namespaces(namespace) previously hard-coded std::env::current_dir(), proving the cwd-anchoring bug described in the recorded review decision was real before 13da02f introduced the start_dir parameter`
- `Confirmed git worktree left clean (git status --short empty) after testing, no source or build-artifact leftovers`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
