### PR TITLE
fix(sessions): parse .c0/config.toml as a document under toml 1.x

### DIFF
--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -126,7 +126,7 @@ fn namespace_from_config_chain(path: &Path) -> Option<String> {
     while let Some(current) = dir {
         let config_file = current.join(".c0/config.toml");
         if let Ok(content) = std::fs::read_to_string(&config_file)
-            && let Ok(config) = content.parse::<toml::Value>()
+            && let Ok(config) = toml::from_str::<toml::Value>(&content)
             && let Some(ns) = config.get("namespace").and_then(|v| v.as_str())
         {
             return Some(ns.to_string());


### PR DESCRIPTION
Fixes #75.

toml 1.x changed `str::parse::<toml::Value>()` to parse a single TOML *value* rather than a document, so `namespace_from_config_chain` failed on every real `.c0/config.toml` (`unexpected content, expected nothing`) and silently fell back to the leaf folder name. Switch to `toml::from_str`, matching the two existing parse sites in `config.rs`.

`walks_up_to_the_nearest_c0_config` fails on `main` since #45 and passes with this change. `./scripts/ci.sh` green locally (44 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkdNoL2Y4PGxNTyWGRZHyM