### PR TITLE
refactor(sessions): extract namespace_for_path from derive_namespace

### DIFF
--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -136,6 +136,26 @@ fn namespace_from_config_chain(path: &Path) -> Option<String> {
     None
 }
 
+/// Resolve a real filesystem path to a namespace: honour the nearest
+/// `.c0/config.toml` in the ancestry, map `$HOME` to `global`, else use the
+/// leaf folder name. Shared path-resolution core behind [`derive_namespace`].
+fn namespace_for_path(path: &Path) -> String {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/home"));
+
+    if let Some(ns) = namespace_from_config_chain(path) {
+        return ns;
+    }
+
+    if path == home {
+        return "global".to_string();
+    }
+
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("global")
+        .to_string()
+}
+
 fn derive_namespace(dir_name: &str) -> String {
     let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/home"));
 
@@ -151,18 +171,7 @@ fn derive_namespace(dir_name: &str) -> String {
             .to_string();
     };
 
-    if let Some(ns) = namespace_from_config_chain(&path) {
-        return ns;
-    }
-
-    if path == home {
-        return "global".to_string();
-    }
-
-    path.file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("global")
-        .to_string()
+    namespace_for_path(&path)
 }
 
 fn file_mtime_ms(path: &PathBuf) -> Option<u64> {
@@ -2310,6 +2319,41 @@ mod enrichment_tests {
             derive_namespace("-home-douglasjordan-does-not-exist-anywhere"),
             "anywhere"
         );
+    }
+
+    #[test]
+    fn namespace_for_path_maps_home_to_global() {
+        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/home"));
+        assert_eq!(namespace_for_path(&home), "global");
+    }
+
+    #[test]
+    fn namespace_for_path_honours_nearest_config() {
+        let root = scratch_dir("nsforpath-config");
+        let project = root.join("reserve-padel");
+        let worktree = project.join("repo").join("main");
+        std::fs::create_dir_all(&worktree).expect("create worktree");
+        std::fs::create_dir_all(project.join(".c0")).expect("create .c0");
+        std::fs::write(
+            project.join(".c0/config.toml"),
+            "namespace = \"reserve-padel\"\n",
+        )
+        .expect("write config");
+
+        assert_eq!(namespace_for_path(&worktree), "reserve-padel");
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn namespace_for_path_falls_back_to_leaf_folder() {
+        let root = scratch_dir("nsforpath-leaf");
+        let project = root.join("cocokind-vbt");
+        std::fs::create_dir_all(&project).expect("create project");
+
+        assert_eq!(namespace_for_path(&project), "cocokind-vbt");
+
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]


### PR DESCRIPTION
## What Changed

- Extracted the path-resolution core of `derive_namespace` into a new `namespace_for_path` function in `src/sessions.rs`, which honors the nearest `.c0/config.toml` in the ancestry, maps `$HOME` to `global`, and otherwise falls back to the leaf folder name.
- `derive_namespace` now delegates to `namespace_for_path` after resolving the directory name to a filesystem path, with no change to its resolution logic or output.
- Added unit tests covering `namespace_for_path` directly: mapping home to `global`, honoring the nearest config file, and falling back to the leaf folder name.

## Risk Assessment

✅ Low: Pure extract-function refactor with behavior-preserving logic and matching new tests; no call sites or semantics changed.

## Testing

This is a pure internal refactor (extracting namespace_for_path out of derive_namespace's body with no logic change); ran the targeted sessions::enrichment_tests suite (cargo test --bin c0 --features sessions), which includes 3 new tests directly exercising namespace_for_path against real temp directories/.c0 config files (home→global, nearest-config resolution, leaf-folder fallback) plus the pre-existing derive_namespace tests, all 13 passing — confirming the refactor preserves observable behavior. No UI/product-facing surface exists for this change, so CLI/API artifacts aren't applicable; the filesystem-backed unit tests are the appropriate evidence here.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b241d37535ab31c803beefc07f6abd3eca882f4a","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cargo test --bin c0 --features sessions sessions::enrichment_tests -- --test-threads=1` (13 tests, all passed)</code>
- `Verified new tests namespace_for_path_maps_home_to_global, namespace_for_path_honours_nearest_config, namespace_for_path_falls_back_to_leaf_folder exercise real filesystem paths/config files, not source-text matching`
- `Confirmed pre-existing derive_namespace tests (falls_back_to_real_basename_without_a_config, unresolvable_paths_keep_legacy_behaviour, walks_up_to_the_nearest_c0_config) still pass, showing the extraction preserved behavior`
- <code>`git status --porcelain` confirms no stray artifacts left in the worktree (target/ is gitignored)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
