### PR TITLE
docs(sessions): document the source-adapter extension point

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,16 @@ If you use [Claude Code](https://claude.com/claude-code), an optional feature in
 cargo install --path . --features sessions
 ```
 
-This is the reference example of c0's **source-adapter** pattern — the same shape any "fill the graph from <source>" integration would take.
+This is the reference example of c0's **source-adapter** pattern — the same shape any "fill the graph from <source>" integration would take. See [Writing a source adapter](#writing-a-source-adapter) below.
+
+### Writing a source adapter
+
+c0 keeps a clean seam between *reading a transcript* and *writing it to the graph*, so new harnesses (Cursor, Aider, Hermes, your own tool) can be added without touching the storage layer. The contract lives in `src/sessions.rs` and has exactly two halves:
+
+1. **Parse** your source into a `ParsedSession` (a normalized session plus its `ParsedTurn`s). `parse_jsonl_file` — the Claude Code JSONL reader — is the reference implementation to copy. This step does no graph I/O; it just maps your transcript format onto the shared model.
+2. **Write** it by handing that `ParsedSession` to `write_parsed_session`, which owns everything downstream: embeddings, node/edge creation, turn dedup, and aggregate rollups. Adapters never talk to Neo4j directly.
+
+So "add a harness" reduces to "write another `parse_*_session` that produces a `ParsedSession`, then call `write_parsed_session`." Both items carry `///` docs spelling out the contract. Out-of-tree adapters (c0 is a binary crate) can vendor or fork this seam; keeping the boundary stable is what makes them cheap to maintain.
 
 ## The reflection loop — c0's learning engine
 

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -621,6 +621,23 @@ pub struct ExtractStats {
     pub errors: u32,
 }
 
+/// The source-adapter contract, part 1 of 2: the normalized session model.
+///
+/// `ParsedSession` (+ its [`ParsedTurn`]s) is the harness-agnostic shape that
+/// sits between *parsing* a transcript and *writing* it to the graph. It is the
+/// seam c0 exposes for adding new session sources ("fill the graph from
+/// `<source>`"):
+///
+/// 1. Parse your source's transcript into a `ParsedSession` — see
+///    [`parse_jsonl_file`] (the Claude Code JSONL adapter) as the reference
+///    implementation.
+/// 2. Hand it to [`write_parsed_session`], which owns all graph writes,
+///    embedding, and aggregation — an adapter never touches Neo4j directly.
+///
+/// Everything below the parse boundary (embeddings, Cypher, dedup, salience) is
+/// shared, so an out-of-tree adapter only has to produce this struct. Fields are
+/// deliberately plain data; populate what your source provides and leave the
+/// rest at [`Default`].
 #[derive(Debug, Clone, Default)]
 struct ParsedSession {
     session_id: String,
@@ -637,6 +654,9 @@ struct ParsedSession {
     backfills: Vec<ToolResultBackfill>,
 }
 
+/// A single normalized turn within a [`ParsedSession`]. See `ParsedSession`
+/// for the source-adapter contract; an adapter fills the fields its source
+/// provides and leaves the rest at [`Default`].
 #[derive(Debug, Clone, Default)]
 struct ParsedTurn {
     turn_id: String,
@@ -768,6 +788,16 @@ fn extract_tool_result_text(content: &serde_json::Value) -> String {
     String::new()
 }
 
+/// Reference source adapter: parse a Claude Code JSONL transcript into a
+/// [`ParsedSession`].
+///
+/// This is the *parse* half of c0's source-adapter contract and the canonical
+/// example to copy when adding a new harness (Cursor, Aider, Hermes, ...): read
+/// your source's transcript, normalize it into a `ParsedSession`/[`ParsedTurn`]
+/// tree, and return it. It does **no** graph I/O — writing is
+/// [`write_parsed_session`]'s job. A new adapter is simply "another
+/// `parse_*_session` that produces a `ParsedSession`"; nothing downstream needs
+/// to know which source it came from.
 fn parse_jsonl_file(
     path: &PathBuf,
     namespace: &str,
@@ -1023,6 +1053,16 @@ async fn embed_text_opt(
     }
 }
 
+/// The *write* half of c0's source-adapter contract: persist a
+/// [`ParsedSession`] into the graph.
+///
+/// This is the single entry point every source adapter funnels into. Once your
+/// `parse_*_session` has produced a `ParsedSession` (see [`parse_jsonl_file`]
+/// for the reference Claude Code adapter), hand it here and this function owns
+/// the rest: embedding, node/edge creation, turn dedup, and aggregate rollups.
+/// Adapters never talk to Neo4j directly — keeping all graph writes behind this
+/// boundary is what lets new harnesses be added (and maintained out of tree)
+/// without touching the storage layer.
 async fn write_parsed_session(
     graph_conn: &neo4rs::Graph,
     parsed: ParsedSession,


### PR DESCRIPTION
## What Changed
- Added a "Writing a source adapter" section to README.md explaining the two-step contract (parse into `ParsedSession`, then call `write_parsed_session`) for adding new session-transcript harnesses.
- Added `///` doc comments in `src/sessions.rs` to `ParsedSession`, `ParsedTurn`, `parse_jsonl_file`, and `write_parsed_session` spelling out the parse/write seam and clarifying that adapters never talk to Neo4j directly.
- No functional or behavioral changes; both files are documentation-only edits.

## Risk Assessment

✅ Low: Documentation-only change (rustdoc comments on ParsedSession/ParsedTurn/parse_jsonl_file/write_parsed_session plus a new README section); verified the claims (parse does no graph I/O, write_parsed_session owns embedding/node-edge creation/turn dedup via delete_session_turns/aggregate rollups, adapters never call graph:: directly) against the actual function bodies and they match, and the README anchor link resolves correctly.

## Testing

This commit is documentation-only (rustdoc comments + a new README section, no code logic changed), so the relevant evidence is that the docs actually build and render correctly for an end reader. Ran `cargo doc --no-deps --features sessions --document-private-items`, which compiled cleanly with zero rustdoc warnings, then inspected the generated HTML for ParsedSession/ParsedTurn/parse_jsonl_file/write_parsed_session and confirmed every new intra-doc link (`[ParsedSession]`, `[ParsedTurn]`, `[parse_jsonl_file]`, `[write_parsed_session]`, `[Default]`) resolved to a real, correct hyperlink rather than a broken/plain-text fallback. Also rendered README.md with pandoc and confirmed the generated `writing-a-source-adapter` anchor id matches the new `(#writing-a-source-adapter)` link added above the section. No functional Rust code changed, so no unit/integration test run was applicable; cleaned up the generated target/doc directory afterward. Overall result: the new documentation is internally consistent and renders correctly end-to-end.

<details>
<summary>Evidence: cargo doc build output (clean, no broken-link warnings)</summary>

```text
cargo doc --no-deps --features sessions --document-private-items
...
Documenting c0 v0.1.0 (...)
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 20s
Generated .../target/doc/c0/index.html
(no rustdoc warnings emitted)
```
</details>
<details>
<summary>Evidence: Rendered rustdoc cross-reference links for the new source-adapter doc comments</summary>

```text
struct.ParsedSession.html docblock:
<a href="struct.ParsedTurn.html">ParsedTurn</a>
<a href="fn.parse_jsonl_file.html">parse_jsonl_file</a>
<a href="fn.write_parsed_session.html">write_parsed_session</a>
<a href="https://doc.rust-lang.org/.../trait.Default.html">Default</a>
fn.parse_jsonl_file.html docblock links to struct.ParsedSession.html and fn.write_parsed_session.html
fn.write_parsed_session.html docblock links to struct.ParsedSession.html and fn.parse_jsonl_file.html
struct.ParsedTurn.html docblock links to struct.ParsedSession.html and Default
All intra-doc links resolved to real hrefs (no unresolved/broken-link fallbacks).
```
</details>
<details>
<summary>Evidence: README.md rendered to HTML via pandoc, confirming #writing-a-source-adapter anchor matches the new inline link target</summary>

```text
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml">
<head>
  <meta charset="utf-8" />
  <meta name="generator" content="pandoc" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
  <title>README</title>
  <style>
    /* Default styles provided by pandoc.
    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
    */
    html {
      color: #1a1a1a;
      background-color: #fdfdfd;
    }
    body {
      margin: 0 auto;
      max-width: 36em;
      padding-left: 50px;
      padding-right: 50px;
      padding-top: 50px;
      padding-bottom: 50px;
      hyphens: auto;
      overflow-wrap: break-word;
      text-rendering: optimizeLegibility;
      font-kerning: normal;
    }
    @media (max-width: 600px) {
      body {
        font-size: 0.9em;
        padding: 12px;
      }
      h1 {
        font-size: 1.8em;
      }
    }
    @media print {
      html {
        background-color: white;
      }
      body {
        background-color: transparent;
        color: black;
        font-size: 12pt;
      }
      p, h2, h3 {
        orphans: 3;
        widows: 3;
      }
      h2, h3, h4 {
        page-break-after: avoid;
      }
    }
    p {
      margin: 1em 0;
    }
    a {
      color: #1a1a1a;
    }
    a:visited {
      color: #1a1a1a;
    }
    img {
      max-width: 100%;
    }
    svg {
      height: auto;
      max-width: 100%;
    }
    h1, h2, h3, h4, h5, h6 {
      margin-top: 1.4em;
    }
    h5, h6 {
      font-size: 1em;
      font-style: italic;
    }
    h6 {
      font-weight: normal;
    }
    ol, ul {
      padding-left: 1.7em;
      margin-top: 1em;
    }
    li > ol, li > ul {
      margin-top: 0;
    }
    blockquote {
      margin: 1em 0 1em 1.7em;
      padding-left: 1em;
      border-left: 2px solid #e6e6e6;
      color: #606060;
    }
    code {
      white-space: pre-wrap;
      font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
      font-size: 85%;
      margin: 0;
      hyphens: manual;
    }
    pre {
      margin: 1em 0;
      overflow: auto;
    }
    pre code {
      padding: 0;
      overflow: visible;
      overflow-wrap: normal;
    }
    .sourceCode {
     background-color: transparent;
     overflow: visible;
    }
    hr {
      border: none;
      border-top: 1px solid #1a1a1a;
      height: 1px;
      margin: 1em 0;
    }
    table {
      margin: 1em 0;
      border-collapse: collapse;
      width: 100%;
      overflow-x: auto;
      display: block;
      font-variant-numeric: lining-nums tabular-nums;
    }
    table caption {
      margin-bottom: 0.75em;
    }
    tbody {
      margin-top: 0.5em;
      border-top: 1px solid #1a1a1a;
      border-bottom: 1px solid #1a1a1a;
    }
    th {
      border-top: 1px solid #1a1a1a;
      padding: 0.25em 0.5em 0.25em 0.5em;
    }
    td {
      padding: 0.125em 0.5em 0.25em 0.5em;
    }
    header {
      margin-bottom: 4em;
      text-align: center;
    }
    #TOC li {
      list-style: none;
    }
    #TOC ul {
      padding-left: 1.3em;
    }
    #TOC > ul {
      padding-left: 0;
    }
    #TOC a:not(:hover) {
      text-decoration: none;
    }
    span.smallcaps{font-variant: small-caps;}
    div.columns{display: flex; gap: min(4vw, 1.5em);}
    div.column{flex: auto; overflow-x: auto;}
    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
    /* The extra [class] is a hack that increases specificity enough to
       override a similar rule in reveal.js */
    ul.task-list[class]{list-style: none;}
    ul.task-list li input[type="checkbox"] {
      font-size: inherit;
      width: 0.8em;
      margin: 0 0.8em 0.2em -1.6em;
      vertical-align: middle;
    }
    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
    /* CSS for syntax highlighting */
    html { -webkit-text-size-adjust: 100%; }
    pre > code.sourceCode { white-space: pre; position: relative; }
    pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
    pre > code.sourceCode > span:empty { height: 1.2em; }
    .sourceCode { overflow: visible; }
    code.sourceCode > span { color: inherit; text-decoration: inherit; }
    div.sourceCode { margin: 1em 0; }
    pre.sourceCode { margin: 0; }
    @media screen {
    div.sourceCode { overflow: auto; }
    }
    @media print {
    pre > code.sourceCode { white-space: pre-wrap; }
    pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
    }
    pre.numberSource code
      { counter-reset: source-line 0; }
    pre.numberSource code > span
      { position: relative; left: -4em; counter-increment: source-line; }
    pre.numberSource code > span > a:first-child::before
      { content: counter(source-line);
        position: relative; left: -1em; text-align: right; vertical-align: baseline;
        border: none; display: inline-block;
        -webkit-touch-callout: none; -webkit-user-select: none;
        -khtml-user-select: none; -moz-user-select: none;
        -ms-user-select: none; user-select: none;
        padding: 0 4px; width: 4em;
        color: #aaaaaa;
      }
    pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
    div.sourceCode
      {   }
    @media screen {
    pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
    }
    code span.al { color: #ff0000; font-weight: bold; } /* Alert */
    code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
    code span.at { color: #7d9029; } /* Attribute */
    code span.bn { color: #40a070; } /* BaseN */
    code span.bu { color: #008000; } /* BuiltIn */
    code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
    code span.ch { color: #4070a0; } /* Char */
    code span.cn { color: #880000; } /* Constant */
    code span.co { color: #60a0b0; font-style: italic; } /* Comment */
    code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
    code span.do { color: #ba2121; font-style: italic; } /* Documentation */
    code span.dt { color: #902000; } /* DataType */
    code span.dv { color: #40a070; } /* DecVal */
    code span.er { color: #ff0000; font-weight: bold; } /* Error */
    code span.ex { } /* Extension */
    code span.fl { color: #40a070; } /* Float */
    code span.fu { color: #06287e; } /* Function */
    code span.im { color: #008000; font-weight: bold; } /* Import */
    code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
    code span.kw { color: #007020; font-weight: bold; } /* Keyword */
    code span.op { color: #666666; } /* Operator */
    code span.ot { color: #007020; } /* Other */
    code span.pp { color: #bc7a00; } /* Preprocessor */
    code span.sc { color: #4070a0; } /* SpecialChar */
    code span.ss { color: #bb6688; } /* SpecialString */
    code span.st { color: #4070a0; } /* String */
    code span.va { color: #19177c; } /* Variable */
    code span.vs { color: #4070a0; } /* VerbatimString */
    code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
  </style>
</head>
<body>
<h1 id="c0">c0</h1>
<p><strong>An external memory for LLMs</strong> — a bi-temporal
knowledge graph with hybrid (keyword + vector) retrieval and a
self-improving reflection loop.</p>
<p><img src="assets/brain.png"
alt="c0 — a live knowledge graph of ~95,000 concepts, sessions, and the relationships between them" /></p>
<p><a
href="https://github.com/douglasjordan2/c0/actions/workflows/ci.yml"><img
src="https://github.com/douglasjordan2/c0/actions/workflows/ci.yml/badge.svg"
alt="CI" /></a> <a href="./LICENSE"><img
src="https://img.shields.io/badge/License-MIT-blue.svg"
alt="License: MIT" /></a> <a href="https://www.rust-lang.org/"><img
src="https://img.shields.io/badge/built%20with-Rust-orange.svg"
alt="Built with Rust" /></a></p>
<hr />
<h2 id="why">Why</h2>
<p>Language models are <strong>stateless between sessions</strong> and
their training data <strong>goes stale</strong>. The usual fix —
stuffing documents into a vector store — retrieves blobs of prose and
has no notion of how knowledge chan

... [43158 bytes truncated] ...

d filled — so the
<em>next</em> lookup that would have missed now hits.</p>
<h3 id="run-it-the-whole-point">Run it (the whole point)</h3>
<p><strong>The loop itself isn't optional — it's what makes c0 a memory
that improves rather than a static store. What's optional is
<em>how</em> you run it.</strong> Recall (<code>walk</code>) and
reflection are the two halves of the same flywheel: one reads the graph,
the other grows it. Skip the reflection half and the graph only ever
holds what you typed in by hand. So the real question isn't
<em>whether</em> to close the loop but <em>how</em> — and that's the
part that takes tuning: too eager and it spams the graph with noise, too
passive and it never learns. Pick a mechanism that fits your workflow
and commit to it; everything below is just options.</p>
<p>The simplest is the built-in watch mode — it classifies the inbox,
applies the commits, sleeps, and repeats:</p>
<div class="sourceCode" id="cb14"><pre
class="sourceCode bash"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector run                      <span class="co"># tick every hour, auto-commit the COMMITs</span></span>
<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector run <span class="at">--interval</span> 15m       <span class="co"># tick more often</span></span>
<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector run <span class="at">--no-apply</span>           <span class="co"># classify only; hold COMMITs for human review</span></span></code></pre></div>
<p>For an always-on, unattended setup, prefer <strong>discrete scheduled
runs</strong> over the long-lived <code>c0 reflector run</code> loop. A
systemd timer (or cron) firing <code>process</code> → <code>apply</code>
each hour avoids clock drift, gets journald logging, and — with
<code>OnUnitInactiveSec</code> — won't stack a new run on top of a slow
one. Ready-to-edit user units ship in <a
href="scripts/systemd/"><code>scripts/systemd/</code></a>:</p>
<div class="sourceCode" id="cb15"><pre
class="sourceCode bash"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">mkdir</span> <span class="at">-p</span> ~/.config/systemd/user</span>
<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a><span class="fu">cp</span> scripts/systemd/c0-reflector.<span class="dt">{service</span><span class="op">,</span><span class="dt">timer}</span> ~/.config/systemd/user/</span>
<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a><span class="co"># edit the Environment= / ExecStart= paths, then:</span></span>
<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a><span class="ex">systemctl</span> <span class="at">--user</span> daemon-reload</span>
<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a><span class="ex">systemctl</span> <span class="at">--user</span> enable <span class="at">--now</span> c0-reflector.timer</span></code></pre></div>
<p>Cron works too:</p>
<pre class="cron"><code># Classify dead ends every hour and auto-commit. Keep a human in the loop?
# Drop the &quot;&amp;&amp; c0 reflector apply&quot; and run `c0 reflector review` when you check in.
0 * * * * c0 reflector process &amp;&amp; c0 reflector apply</code></pre>
<h3 id="inspect-and-steer-it">Inspect and steer it</h3>
<p>The loop is intentionally two-staged (<code>process</code> →
<code>apply</code>) so nothing touches the graph until you say so:</p>
<div class="sourceCode" id="cb17"><pre
class="sourceCode bash"><code class="sourceCode bash"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector status     <span class="co"># how many dead ends are waiting, proposed, or queued</span></span>
<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector process    <span class="co"># LLM classifies the inbox (writes pending commits + review queue)</span></span>
<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector proposed   <span class="co"># preview the concepts it wants to COMMIT</span></span>
<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector apply      <span class="co"># add the pending concepts to the graph</span></span>
<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector review     <span class="co"># walk the QUEUE&#39;d items interactively</span></span>
<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector inbox      <span class="co"># show the raw dead-end inbox</span></span>
<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector notify     <span class="co"># emit a summary of the queue state</span></span>
<span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector clear      <span class="co"># empty the inbox / pending queues</span></span></code></pre></div>
<p><strong>Draining a backlog by hand</strong> — when dead ends have
piled up and you want them in the graph now:</p>
<div class="sourceCode" id="cb18"><pre
class="sourceCode bash"><code class="sourceCode bash"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector status     <span class="co"># see how many are waiting</span></span>
<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector process    <span class="co"># classify them (local Ollama by default)</span></span>
<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector proposed   <span class="co"># eyeball what it wants to COMMIT</span></span>
<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector apply      <span class="co"># commit the good ones</span></span>
<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a><span class="ex">c0</span> reflector review     <span class="co"># walk anything it left QUEUE&#39;d for you</span></span></code></pre></div>
<p>Easier still: hand the backlog to your terminal agent and let it
drive these commands while you decide. Something like <em>"walk me
through the reflector inbox interactively"</em> turns the chore into a
conversation — the agent runs <code>process</code>, reads back what it
wants to COMMIT, and you approve or redirect each call without
memorizing the sequence.</p>
<blockquote>
<p>Classification runs on a <strong>local Ollama model by
default</strong> (<code>hermes3:8b</code>) — no key, no cloud, reusing
the Ollama you already run for embeddings. Want Claude's higher-quality
judgment instead? Point <code>[claude]</code> at the Anthropic API
<em>or</em> your Claude subscription's <code>claude</code> CLI — see <a
href="#configuration">Configuration</a>.</p>
</blockquote>
<h2 id="architecture-notes">Architecture notes</h2>
<p>The retrieval core lives in <code>src/graph.rs</code> (Cypher
queries, the BM25/vector/RRF functions, temporal filters) and
<code>src/embeddings.rs</code> (Ollama client + cosine similarity). The
reflection loop is in <code>src/reflector.rs</code>. Hybrid search
defaults — <code>alpha = 0.4</code> (keyword vs. vector weight),
<code>k = 60</code> (the canonical RRF constant), a <code>0.3</code>
vector threshold — are defined in <code>HybridSearchConfig</code>.</p>
<h2 id="contributing">Contributing</h2>
<p>Issues and PRs welcome. The codebase forbids <code>unsafe</code> and
lints with Clippy <code>pedantic</code>; please keep new code
warning-clean and run <code>cargo build --features sessions</code> as
well as the default build.</p>
<h2 id="license">License</h2>
<p><a href="./LICENSE">MIT</a></p>
</body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"11588e1f855dde3f6993986f2e6997f3536074d3","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo doc --no-deps --features sessions --document-private-items (clean build, no rustdoc warnings)`
- `Inspected generated target/doc/c0/sessions/{struct.ParsedSession,struct.ParsedTurn,fn.parse_jsonl_file,fn.write_parsed_session}.html docblocks to confirm all new intra-doc links resolve to correct hrefs`
- `pandoc README.md -f gfm -t html -s -o .../README.rendered.html, then verified the generated anchor id 'writing-a-source-adapter' matches the new README link target`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
